### PR TITLE
Upgrade to qulice 0.17.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,11 +101,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>checkstyle:/src/site/resources/.*</exclude>
-              </excludes>
-            </configuration>
+            <version>0.17.3</version>
           </plugin>
           <plugin>
             <groupId>org.jacoco</groupId>

--- a/src/main/java/org/llorllale/cactoos/matchers/FuncApplies.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/FuncApplies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -36,8 +36,6 @@ import org.hamcrest.core.IsEqual;
 /**
  * Matcher for the value.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <X> Type of input
  * @param <Y> Type of output
  * @since 0.2

--- a/src/main/java/org/llorllale/cactoos/matchers/InputHasContent.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/InputHasContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -37,8 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Matcher for the input.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  * @todo #7:30min All the matchers should implement describeMismatchSafely and
  *  their tests must verify that the implementation of the descriptions

--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -38,8 +38,6 @@ import org.hamcrest.TypeSafeMatcher;
  *
  * <p>There is no thread-safety guarantee.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <T> Type of object to match
  * @since 0.12
  */

--- a/src/main/java/org/llorllale/cactoos/matchers/RunsInThreads.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/RunsInThreads.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -42,8 +42,6 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Matcher for {@link Func} that must run in multiple threads.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <T> Type of input
  * @since 0.24
  * @checkstyle JavadocMethodCheck (500 lines)

--- a/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -36,8 +36,6 @@ import org.hamcrest.core.IsEqual;
 /**
  * Matcher for the value.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <T> Type of result
  * @since 0.2
  */

--- a/src/main/java/org/llorllale/cactoos/matchers/TeeInputHasResult.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TeeInputHasResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -42,8 +42,6 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Matcher for the {@link TeeInput}'s results.
  *
- * @author Roman Proshin (roman@proshin.org)
- * @version $Id$
  * @since 1.0
  */
 public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {

--- a/src/main/java/org/llorllale/cactoos/matchers/TextHasString.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TextHasString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -36,8 +36,6 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Matches if a text <em>contains</em> this string.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  */
 public final class TextHasString extends TypeSafeMatcher<Text> {

--- a/src/main/java/org/llorllale/cactoos/matchers/TextIs.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TextIs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -35,8 +35,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matches if a text equals this string.
- * @author George Aristy (george.aristy@gmail.com)
- * @version $Id$
  * @since 1.0.0
  */
 public final class TextIs extends TypeSafeMatcher<Text> {

--- a/src/main/java/org/llorllale/cactoos/matchers/package-info.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -28,8 +28,6 @@
 /**
  * An extension of cactoos with object-oriented hamcrest matchers.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  */
 package org.llorllale.cactoos.matchers;

--- a/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -33,8 +33,6 @@ import org.junit.Test;
 /**
  * Test case for {@link org.llorllale.cactoos.matchers.FuncApplies}.
  *
- * @author Alexander Menshikov (sharplermc@gmail.com)
- * @version $Id$
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/InputHasContentTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/InputHasContentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -35,8 +35,6 @@ import org.junit.Test;
 /**
  * Test case for {@link org.llorllale.cactoos.matchers.InputHasContent}.
  *
- * @author Vedran Vatavuk (123vgv@gmail.com)
- * @version $Id$
  * @since 1.1
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -38,8 +38,6 @@ import org.junit.Test;
 /**
  * Test case for {@link org.llorllale.cactoos.matchers.RunsInThreads}.
  *
- * @author Alexander Menshikov (sharplermc@gmail.com)
- * @version $Id$
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -39,9 +39,6 @@ import org.junit.rules.ExpectedException;
 /**
  * Test case for {@link ScalarHasValue}.
  *
- * @author Alexander Menshikov (sharplermc@gmail.com)
- * @author Victor Noel (victor.noel@crazydwarves.org)
- * @version $Id$
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/TeeInputHasResultTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TeeInputHasResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -38,8 +38,6 @@ import org.junit.Test;
 /**
  * Test case for {@link TeeInputHasResult}.
  *
- * @author Roman Proshin (roman@proshin.org)
- * @version $Id$
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -40,8 +40,6 @@ import org.junit.Test;
 /**
  * Test case for {@link TextHasString}.
  *
- * @author Nikita Salomatin (nsalomatin@hotmail.com)
- * @version $Id$
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 /**
  * Tests for {@link TextIs}.
- * @author George Aristy (george.aristy@gmail.com)
- * @version $Id$
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/package-info.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) for portions of project cactoos-matchers are held by
@@ -28,8 +28,6 @@
 /**
  * Matcher's tests.
  *
- * @author Nikita Salomatin (nsalomatin@hotmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.llorllale.cactoos.matchers;


### PR DESCRIPTION
For #10

This upgrades qulice to 0.17.3 and fixes the resultant errors: it removes the newly prohibited @version @author tags and changes the opening comment for each licence header.  Also removed checkstyle exclusion on resources folder, which does not break the build.
