### PR TITLE
For #23: `TextIs` wrong message

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
@@ -28,8 +28,12 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Func;
 import org.cactoos.Proc;
+import org.cactoos.Text;
 import org.cactoos.func.FuncOf;
 import org.cactoos.func.UncheckedFunc;
+import org.cactoos.text.JoinedText;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
@@ -49,6 +53,11 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
     private final Func<T, Boolean> func;
 
     /**
+     * Matcher description.
+     */
+    private final UncheckedText desc;
+
+    /**
      * Ctor.
      * @param proc The func
      */
@@ -61,8 +70,25 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
      * @param fnc The func
      */
     public MatcherOf(final Func<T, Boolean> fnc) {
+        this(fnc, new UncheckedText(fnc.toString()));
+    }
+
+    /**
+     * Ctor.
+     * @param fnc The func
+     * @param description The description
+     */
+    public MatcherOf(final Func<T, Boolean> fnc, final Text description) {
         super();
         this.func = fnc;
+        this.desc = new UncheckedText(
+            new JoinedText(
+                new TextOf(""),
+                new TextOf("\""),
+                description,
+                new TextOf("\"")
+            )
+        );
     }
 
     @Override
@@ -72,6 +98,6 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText(this.func.toString());
+        description.appendText(this.desc.asString());
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
@@ -31,8 +31,7 @@ import org.cactoos.Proc;
 import org.cactoos.Text;
 import org.cactoos.func.FuncOf;
 import org.cactoos.func.UncheckedFunc;
-import org.cactoos.text.JoinedText;
-import org.cactoos.text.TextOf;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -82,12 +81,7 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
         super();
         this.func = fnc;
         this.desc = new UncheckedText(
-            new JoinedText(
-                new TextOf(""),
-                new TextOf("\""),
-                description,
-                new TextOf("\"")
-            )
+            new FormattedText("\"%s\"", description)
         );
     }
 

--- a/src/main/java/org/llorllale/cactoos/matchers/TextIs.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TextIs.java
@@ -41,7 +41,7 @@ public final class TextIs extends TypeSafeMatcher<Text> {
     /**
      * Prefix for description.
      */
-    private static final String PREFIX = "Text with ";
+    private static final String PREFIX = "Text with value ";
 
     /**
      * Matcher of the text.
@@ -67,7 +67,10 @@ public final class TextIs extends TypeSafeMatcher<Text> {
      */
     public TextIs(final Text text) {
         this(
-            new MatcherOf<>((String input) -> input.equals(text.asString()))
+            new MatcherOf<>(
+                (String input) -> input.equals(text.asString()),
+                text
+            )
         );
     }
 


### PR DESCRIPTION
For #23:
- Corrected `TextIs` message;
- Added constructor to `MatcherOf` allowing description injection