### PR TITLE
(#58) Examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Java version required: 1.8+.
 
 cactoos-matchers | Hamcrest (static method) | Hamcrest (object) | JUnit
 ------ | ------ | ------ | ------
-`Assertion` | `MatcherAssert.assertThat` | - | -
+`Assertion` | `MatcherAssert.assertThat` | - | `Assert.assertThat`
 `Throws` | - | - | `@expected` + `ExpectedException`
 `EndsWith` | `Matchers.endsWith` | `StringEndsWith` | -
 `StartsWith` | `Matcers.startsWith` | `StringStartsWith` | -

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Java version required: 1.8+.
 ## cactoos-matchers versus Hamcrest/JUnit
 
 cactoos-matchers | Hamcrest (static method) | Hamcrest (object) | JUnit
----------------- | --------
+------ | ------
 `Assertion` | `MatcherAssert.assertThat` | - | -
 `Throws` | - | - | `@expected`/`ExpectedException`
 `EndsWith` | `Matchers.endsWith` | `StringEndsWith` | -

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Get the latest version [here](https://github.com/llorllale/cactoos-matchers/rele
 
 Java version required: 1.8+.
 
-## cactoos-matchers versus Hamcrest/JUnit
+## cactoos-matchers versus Hamcrest + JUnit
 
 cactoos-matchers | Hamcrest (static method) | Hamcrest (object) | JUnit
------- | ------
+------ | ------ | ------ | ------
 `Assertion` | `MatcherAssert.assertThat` | - | -
-`Throws` | - | - | `@expected`/`ExpectedException`
+`Throws` | - | - | `@expected` + `ExpectedException`
 `EndsWith` | `Matchers.endsWith` | `StringEndsWith` | -
 `StartsWith` | `Matcers.startsWith` | `StringStartsWith` | -
 `TextIs` | `Matchers.is` | `IsEqual` | -

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ Get the latest version [here](https://github.com/llorllale/cactoos-matchers/rele
 
 Java version required: 1.8+.
 
+## cactoos-matchers versus Hamcrest/JUnit
+
+cactoos-matchers | Hamcrest (static method) | Hamcrest (object) | JUnit
+---------------- | --------
+`Assertion` | `MatcherAssert.assertThat` | - | -
+`Throws` | - | - | `@expected`/`ExpectedException`
+`EndsWith` | `Matchers.endsWith` | `StringEndsWith` | -
+`StartsWith` | `Matcers.startsWith` | `StringStartsWith` | -
+`TextIs` | `Matchers.is` | `IsEqual` | -
+`HasLines` | - | - | -
+`MatchesRegex` | - | - | -
+`TextHasString` | `Matchers.stringContainsInOrder` | `StringContains` | -
+`FuncApplies` | - | - | -
+`HasValues` | `Matchers.containsInAnyOrder` | `IsIterableContainingInAnyOrder` | -
+`HasValuesMatching` | `Matchers.containsInAnyOrder` | `IsIterableContainingInAnyOrder` | -
+`InputHasContent` | - | - | -
+`IsTrue` | - | - | `Assert.assertTrue`
+`Matches` | - | - | -
+`RunsInThreads` | - | - | -
+`ScalarHasValue` | - | - | -
+
 ## How to use
 
 Use our matchers inside your JUnit [`@Test`](http://junit.sourceforge.net/javadoc/org/junit/Test.html) case. We also provide `Assertion<T>` in which you can compose the behavior under test and the test case's matcher, and attempt to affirm it.

--- a/src/main/java/org/llorllale/cactoos/matchers/NotBlank.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/NotBlank.java
@@ -33,10 +33,10 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * The matcher to check that text is not empty.
  *
  * @since 1.0.0
- * @checkstyle ProtectedMethodInFinalClassCheck (100 lines)
  * @todo #58:30min NotBlank should be changed to `IsBlank`. Users should
  *  be able to negate it by simply decorating it with `IsNot`. Update the
  *  README once done.
+ * @checkstyle ProtectedMethodInFinalClassCheck (100 lines)
  */
 public final class NotBlank extends TypeSafeDiagnosingMatcher<String> {
 

--- a/src/main/java/org/llorllale/cactoos/matchers/NotBlank.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/NotBlank.java
@@ -34,6 +34,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * @since 1.0.0
  * @checkstyle ProtectedMethodInFinalClassCheck (100 lines)
+ * @todo #58:30min NotBlank should be changed to `IsBlank`. Users should
+ *  be able to negate it by simply decorating it with `IsNot`. Update the
+ *  README once done.
  */
 public final class NotBlank extends TypeSafeDiagnosingMatcher<String> {
 

--- a/src/main/java/org/llorllale/cactoos/matchers/TeeInputHasResult.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TeeInputHasResult.java
@@ -43,6 +43,9 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher for the {@link TeeInput}'s results.
  *
  * @since 1.0
+ * @todo #58:30min Delete TeeInputHasResult from the library. It's too specific.
+ *  Users should use InputHasContent instead. Should be moved to test packages
+ *  in cactoos.
  */
 public final class TeeInputHasResult extends TypeSafeMatcher<TeeInput> {
 


### PR DESCRIPTION
This PR is for #58:
* Updated README with a few examples.
* Updated README with a table of comparisons (us vs hamcrest + junit)
* left puzzle to remove `TeeInputHasResults`
* left puzzle to reverse logic of `NotBlank` (should be `IsBlank`)