### PR TITLE
#60: Text matchers should describe actual/expected values separately

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/TextMatcherEnvelope.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TextMatcherEnvelope.java
@@ -36,18 +36,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * The Text-based {@link TypeSafeDiagnosingMatcher} envelope.
  *
  * @since 1.0.0
- * @todo #16:30min Extends the envelope in TextIs, TextHasString, StartsWith,
- *  EndsWith. Most of operations with text like startsWith, endsWith, contains,
- *  equals, etc has the same algorithm. There is only difference in the function
- *  which should be applied to text.
  */
 public abstract class TextMatcherEnvelope extends
     TypeSafeDiagnosingMatcher<Text> {
-
-    /**
-     * The description of the matcher's actual/expected values.
-     */
-    private final String description;
 
     /**
      * The matcher to test.
@@ -55,25 +46,50 @@ public abstract class TextMatcherEnvelope extends
     private final Matcher<Text> matcher;
 
     /**
+     * The description of the matcher's expected text.
+     */
+    private final String expected;
+
+    /**
+     * The description of the matcher's actual text.
+     */
+    private final String actual;
+
+    /**
      * Ctor.
      * @param mtchr The matcher to test.
-     * @param desc The description of the matcher's actual/expected values.
+     * @param expected The description of the matcher's expected text.
      */
-    public TextMatcherEnvelope(final Matcher<Text> mtchr, final String desc) {
+    public TextMatcherEnvelope(
+        final Matcher<Text> mtchr, final String expected
+    ) {
+        this(mtchr, expected, "Text is ");
+    }
+
+    /**
+     * Ctor.
+     * @param mtchr The matcher to test.
+     * @param expected The description of the matcher's expected text.
+     * @param actual The description of the matcher's actual text.
+     */
+    public TextMatcherEnvelope(
+        final Matcher<Text> mtchr, final String expected, final String actual
+    ) {
         super();
         this.matcher = mtchr;
-        this.description = desc;
+        this.expected = expected;
+        this.actual = actual;
     }
 
     @Override
     public final void describeTo(final Description desc) {
-        desc.appendText(this.description).appendDescriptionOf(this.matcher);
+        desc.appendText(this.expected).appendDescriptionOf(this.matcher);
     }
 
     @Override
     protected final boolean matchesSafely(final Text text,
         final Description desc) {
-        desc.appendText(this.description).appendValue(
+        desc.appendText(this.actual).appendValue(
             new UncheckedText(text).asString()
         );
         return this.matcher.matches(text);

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -80,7 +80,7 @@ public final class EndsWithTest {
         MatcherAssert.assertThat(
             "The matcher print the value which came for testing",
             desc.toString(),
-            new IsEqual<>("Text ending with \"ABC\"")
+            new IsEqual<>("Text is \"ABC\"")
         );
     }
 

--- a/src/test/java/org/llorllale/cactoos/matchers/MatchesRegexTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatchesRegexTest.java
@@ -69,21 +69,6 @@ public final class MatchesRegexTest {
      * Matcher prints the actual value(s) properly in case of errors.
      * The actual/expected section are using only when testing is failed and
      *  we need to explain what exactly went wrong.
-     * @todo #35:30min The TextMatcherEnvelope should support the description
-     *  for actual/expected values separately. For example, for now we are
-     *  using single `TextMatcherEnvelope#TextMatcherEnvelope(Matcher, String)`
-     *  description object which describe actual/expected objects and leads to
-     *  uninformative message in case of failure of MatchesRegexp. For example
-     *  <pre>{@code
-     *  java.lang.AssertionError:
-     *  Expected: Text matches "^.*know\sit\.$"
-     *  but:      Text matches "I'm simple."
-     *  }</pre> Its better to have this error message
-     *  <pre>{@code
-     *  java.lang.AssertionError:
-     *  Expected: Text matches "^.*know\sit\.$"
-     *  but:      Text is "I'm simple."
-     *  }</pre>
      */
     @Test
     public void describeActualValues() {
@@ -94,7 +79,7 @@ public final class MatchesRegexTest {
                 new MatchesRegex("").matchesSafely(new TextOf("ABC"), desc);
                 return desc.toString();
             },
-            new IsEqual<>("Text matches \"ABC\"")
+            new IsEqual<>("Text is \"ABC\"")
         ).affirm();
     }
 

--- a/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
@@ -80,7 +80,7 @@ public final class StartsWithTest {
         MatcherAssert.assertThat(
             "The matcher print the value which came for testing",
             desc.toString(),
-            new IsEqual<>("Text starting with \"ABC\"")
+            new IsEqual<>("Text is \"ABC\"")
         );
     }
 

--- a/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
@@ -61,9 +61,7 @@ public final class TextHasStringTest {
         MatcherAssert.assertThat(
             "Description is not clear ",
             description.toString(),
-            new StringContains(
-                "Text with \"ed076287532e86365e841e92bfc50d8c\""
-            )
+            new StringContains("Text is \"ed076287532e86365e841e92bfc50d8c\"")
         );
     }
 


### PR DESCRIPTION
#60 