### PR TITLE
#52: Replace all uses of MatcherAssert.assertThat() with Assertion

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
@@ -68,9 +68,6 @@ import org.hamcrest.StringDescription;
  *
  * @param <T> The type of the result returned by the operation under test
  * @since 1.0.0
- * @todo #18:30min Replace all uses of MatcherAssert.assertThat() with
- *  Assertion, and ban all overloads of the former in forbidden-apis.txt.
- *  We should also look into banning common matchers like Matchers.is(), etc.
  * @todo #18:30min Assertion relies on the operation under test to be idempotent
  *  in order to match "error matchers" such as `Throws` as expected. This may
  *  not be the case for all operations and could be a problem. Investigate if

--- a/src/main/java/org/llorllale/cactoos/matchers/HasValues.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValues.java
@@ -37,8 +37,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * <p>Here is an example how {@link HasValues} can be used:</p>
  * <pre>
- *  MatcherAssert.assertThat(
- *     new ListOf<>(1, 2, 3),
+ *  new Assertion<>(
+ *     "The list of [1, 2, 3] contains 2"
+ *     () -> new ListOf<>(1, 2, 3),
  *     new HasValues<>(2)
  * );</pre>
  *

--- a/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
@@ -42,7 +42,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * <p>Here is an example how {@link HasValuesMatching} can be used:</p>
  * <pre>
  *  new Assertion<>(
- *     "The list of [1, 2, 3] has values which are more that 2 or less than 3"
+ *     "The list of [1, 2, 3] has values which are more than 2 or less than 3"
  *     () -> new ListOf<>(1, 2, 3),
  *     new HasValuesMatching<>(value -> value > 2 || value == 3)
  * );</pre>

--- a/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
@@ -41,8 +41,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * <p>Here is an example how {@link HasValuesMatching} can be used:</p>
  * <pre>
- *  MatcherAssert.assertThat(
- *     new ListOf<>(1, 2, 3),
+ *  new Assertion<>(
+ *     "The list of [1, 2, 3] has values which are more that 2 or less than 3"
+ *     () -> new ListOf<>(1, 2, 3),
  *     new HasValuesMatching<>(value -> value > 2 || value == 3)
  * );</pre>
  *

--- a/src/main/java/org/llorllale/cactoos/matchers/Matches.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Matches.java
@@ -37,8 +37,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * <pre>{@code
  *  @Test
  *  public void matches() {
- *      MatcherAssert.assertThat(
- *          new TextIs("abc"),
+ *      new Assertion<>(
+ *          "Verify that new matcher gives positive result for valid arguments",
+ *          () -> new TextIs("abc"),
  *          new Matches<>(new TextOf("abc"))
  *      );
  *  }

--- a/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
@@ -81,10 +81,6 @@ public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
     @Override
     protected void describeMismatchSafely(final Scalar<T> item,
         final Description description) {
-        description
-            .appendText("was ")
-            .appendValue(
-                new UncheckedScalar<>(item).value()
-            );
+        description.appendValue(new UncheckedScalar<>(item).value());
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/Throws.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Throws.java
@@ -37,7 +37,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * <p>Here is an example how {@link Throws} can be used:</p>
  * <pre>
- *  MatcherAssert.assertThat(
+ *  new Assertion<>(
  *       "The matcher check that [1,2,3] contains [2]",
  *       () -> {
  *            throw new IllegalArgumentException("No object(s) found.");

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -46,11 +45,11 @@ public final class EndsWithTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives positive result for the valid arguments",
-            new TextOf("I'm simple and I know it."),
+            () -> new TextOf("I'm simple and I know it."),
             new EndsWith("know it.")
-        );
+        ).affirm();
     }
 
     /**
@@ -58,14 +57,14 @@ public final class EndsWithTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives negative result for the invalid arguments",
-            new EndsWith("!").matchesSafely(
+            () -> new EndsWith("!").matchesSafely(
                 () -> "The sentence.",
                 new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -75,13 +74,15 @@ public final class EndsWithTest {
      */
     @Test
     public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new EndsWith("").matchesSafely(new TextOf("ABC"), desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new EndsWith("").matchesSafely(new TextOf("ABC"), desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text is \"ABC\"")
-        );
+        ).affirm();
     }
 
     /**
@@ -90,13 +91,15 @@ public final class EndsWithTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new EndsWith("!").describeTo(desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the description of the scenario",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new EndsWith("!").describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text ending with \"!\"")
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
@@ -26,7 +26,6 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -39,11 +38,10 @@ import org.junit.Test;
 public final class FuncAppliesTest {
     @Test
     public void matchFuncs() {
-        final FuncApplies<Integer, Integer> matcher = new FuncApplies<>(1, 1);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't match equaled values",
-            matcher.matchesSafely(x -> x),
+            () -> new FuncApplies<>(1, 1).matchesSafely(x -> x),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasLinesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasLinesTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -44,36 +43,36 @@ public final class HasLinesTest {
 
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match if valid lines are provided",
-            new HasLines(
+            () -> new HasLines(
                 "A", "C"
             ).matchesSafely(
                 String.format("A%nB%nC%n"),
                 new Description.NullDescription()
             ),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void failed() {
         final Description desc = new StringDescription();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must not match if no lines are provided",
-            new HasLines(
+            () -> new HasLines(
                 () -> "Tom", () -> "Mike"
             ).matchesSafely(
                 String.format("Tom%nJohn%n"),
                 desc
             ),
             new IsEqual<>(false)
-        );
-        MatcherAssert.assertThat(
+        ).affirm();
+        new Assertion<>(
             "describes itself in terms of the lines being matched",
-            desc.toString(),
+            desc::toString,
             new IsEqual<>("<Tom, John>")
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesMatchingTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesMatchingTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.list.ListOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -48,11 +47,11 @@ public final class HasValuesMatchingTest {
      */
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher give the positive result for the valid arguments",
-            new ListOf<>(1, 2, 3),
+            () -> new ListOf<>(1, 2, 3),
             new HasValuesMatching<>(value -> value > 1 || value == 3)
-        );
+        ).affirm();
     }
 
     /**
@@ -60,35 +59,37 @@ public final class HasValuesMatchingTest {
      */
     @Test
     public void matchSafely() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher give the negative result for the invalid arguments",
-            new HasValuesMatching<String>(
+            () -> new HasValuesMatching<String>(
                 text -> text.contains("simple")
             ).matchesSafely(
                 new ListOf<>("I'm", "short", "sentence"),
                 new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
      * Matcher prints the actual value(s) properly in case of errors.
      * The actual/expected section are using only when testing is failed and
      *  we need to explain what exactly went wrong.
-    */
+     */
     @Test
     public void describeActualValues() {
-        final Description description = new StringDescription();
-        new HasValuesMatching<Integer>(value -> value > 5)
-            .matchesSafely(new ListOf<>(1, 2, 3), description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            description.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new HasValuesMatching<Integer>(value -> value > 5)
+                    .matchesSafely(new ListOf<>(1, 2, 3), desc);
+                return desc.toString();
+            },
             new IsEqual<>(
                 "No any elements from [1, 2, 3] matches by the function"
             )
-        );
+        ).affirm();
     }
 
     /**
@@ -97,13 +98,16 @@ public final class HasValuesMatchingTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new HasValuesMatching<Integer>(value -> value > 5)
-            .describeTo(description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the optional description of the scenario",
-            description.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new HasValuesMatching<Integer>(value -> value > 5).describeTo(
+                    desc
+                );
+                return desc.toString();
+            },
             new IsEqual<>("The function matches at least 1 element.")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.list.ListOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -50,11 +49,11 @@ public final class HasValuesTest {
      */
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher check that [1,2,3] contains [2]",
-            new ListOf<>(1, 2, 3),
+            () -> new ListOf<>(1, 2, 3),
             new HasValues<>(2)
-        );
+        ).affirm();
     }
 
     /**
@@ -62,14 +61,14 @@ public final class HasValuesTest {
      */
     @Test
     public void matchSafely() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher check that [a,b,c,e] contains [a,b]",
-            new HasValues<>("a", "b").matchesSafely(
+            () -> new HasValues<>("a", "b").matchesSafely(
                 new ListOf<>("a", "b", "c", "e"),
                 new StringDescription()
             ),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     /**
@@ -81,7 +80,7 @@ public final class HasValuesTest {
      * This test is required to check that the result hamcrest message
      * has proper "actual section". For example the test
      * <pre>{@code
-     * MatcherAssert.assertThat(
+     * new Assertion<>(
      *    new ListOf<>(1, 2, 3),
      *    new HasValues<>(5)
      * );
@@ -96,13 +95,17 @@ public final class HasValuesTest {
      */
     @Test
     public void describeActualValues() {
-        final Description description = new StringDescription();
-        new HasValues<>(5).matchesSafely(new ListOf<>(1, 2, 3), description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            description.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new HasValues<>(5).matchesSafely(
+                    new ListOf<>(1, 2, 3), desc
+                );
+                return desc.toString();
+            },
             new IsEqual<>("<1, 2, 3>")
-        );
+        ).affirm();
     }
 
     /**
@@ -110,13 +113,15 @@ public final class HasValuesTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new HasValues<>(3, 4).describeTo(description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which should be present in the "
                 + "target iterable",
-            description.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new HasValues<>(3, 4).describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("<3, 4>")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/InputHasContentTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/InputHasContentTest.java
@@ -26,9 +26,7 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.Input;
 import org.cactoos.io.InputOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
@@ -43,21 +41,19 @@ public final class InputHasContentTest {
     @Test
     public void matchesInputContent() {
         final String text = "Hello World!";
-        final Input input = new InputOf(text);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher does not match equal values",
-            input,
+            () -> new InputOf(text),
             new InputHasContent(text)
-        );
+        ).affirm();
     }
 
     @Test
     public void failsIfContentDoesNotMatch() {
-        final Input input = new InputOf("hello");
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher matches values that are not equal",
-            input,
+            () -> new InputOf("hello"),
             new IsNot<>(new InputHasContent("world"))
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -45,10 +44,10 @@ public final class IsTrueTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives positive result for valid argument.",
-            true, new IsTrue()
-        );
+            () -> true, new IsTrue()
+        ).affirm();
     }
 
     /**
@@ -56,11 +55,11 @@ public final class IsTrueTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives negative result for invalid argument.",
-            new IsTrue().matchesSafely(false, new StringDescription()),
+            () -> new IsTrue().matchesSafely(false, new StringDescription()),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -70,13 +69,15 @@ public final class IsTrueTest {
      */
     @Test
     public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new IsTrue().matchesSafely(false, desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new IsTrue().matchesSafely(false, desc);
+                return desc.toString();
+            },
             new IsEqual<>("<false>")
-        );
+        ).affirm();
     }
 
     /**
@@ -85,12 +86,14 @@ public final class IsTrueTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new IsTrue().describeTo(desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the details about expected value",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new IsTrue().describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("<true>")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
@@ -30,7 +30,6 @@ package org.llorllale.cactoos.matchers;
 import org.cactoos.Text;
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -49,11 +48,11 @@ public final class MatchesTest {
      */
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher TextIs(abc) gives positive result for Text(abc)",
-            new TextIs("abc"),
+            () -> new TextIs("abc"),
             new Matches<>(new TextOf("abc"))
-        );
+        ).affirm();
     }
 
     /**
@@ -61,11 +60,11 @@ public final class MatchesTest {
      */
     @Test
     public void matchStatus() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher TextIs(abc) gives negative result for Text(def)",
-            new Matches<Text>(() -> "def").matches(new TextIs("abc")),
+            () -> new Matches<Text>(() -> "def").matches(new TextIs("abc")),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -73,17 +72,19 @@ public final class MatchesTest {
      */
     @Test
     public void describeActual() {
-        final Description msg = new StringDescription();
-        new Matches<Text>(
-            new TextOf("expected")
-        ).matchesSafely(
-            new TextIs("actual"), msg
-        );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            msg.toString(),
+            () -> {
+                final Description msg = new StringDescription();
+                new Matches<Text>(
+                    new TextOf("expected")
+                ).matchesSafely(
+                    new TextIs("actual"), msg
+                );
+                return msg.toString();
+            },
             new IsEqual<>("Text with value \"actual\"")
-        );
+        ).affirm();
     }
 
     /**
@@ -91,12 +92,14 @@ public final class MatchesTest {
      */
     @Test
     public void describeExpected() {
-        final Description msg = new StringDescription();
-        new Matches<Text>(new TextOf("expected")).describeTo(msg);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which is expected to be present",
-            msg.toString(),
+            () -> {
+                final Description msg = new StringDescription();
+                new Matches<Text>(new TextOf("expected")).describeTo(msg);
+                return msg.toString();
+            },
             new IsEqual<>("<expected>")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/NotBlankTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/NotBlankTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -44,38 +43,38 @@ public final class NotBlankTest {
 
     @Test
     public void blank() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must not match an empty string",
-            new NotBlank().matchesSafely(
+            () -> new NotBlank().matchesSafely(
                 "", new Description.NullDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     @Test
     public void notBlank() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match a non-empty string",
-            new NotBlank().matchesSafely(
+            () -> new NotBlank().matchesSafely(
                 "-.$%", new Description.NullDescription()
             ),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void nonBlankMessage() {
         final Description desc = new StringDescription();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match a non-empty string",
-            new NotBlank().matchesSafely("text", desc),
+            () -> new NotBlank().matchesSafely("text", desc),
             new IsEqual<>(true)
-        );
-        MatcherAssert.assertThat(
+        ).affirm();
+        new Assertion<>(
             "must describe itself in terms of the text being matched against",
-            desc.toString(),
+            desc::toString,
             new IsEqual<>("\"text\"")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -45,24 +44,28 @@ public final class RunsInThreadsTest {
 
     @Test
     public void matchPositive() {
-        final RunsInThreads<Map<Integer, Integer>> matcher =
-            new RunsInThreads<>(new ConcurrentHashMap<>());
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't concurrently modify ConcurrentHashMap",
-            matcher.matchesSafely(RunsInThreadsTest::modify),
+            () -> {
+                final RunsInThreads<Map<Integer, Integer>> matcher =
+                    new RunsInThreads<>(new ConcurrentHashMap<>());
+                return matcher.matchesSafely(RunsInThreadsTest::modify);
+            },
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchNegative() {
-        final RunsInThreads<Map<Integer, Integer>> matcher =
-            new RunsInThreads<>(new HashMap<>());
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can concurrently modify HashMap",
-            matcher.matchesSafely(RunsInThreadsTest::modify),
+            () -> {
+                final RunsInThreads<Map<Integer, Integer>> matcher =
+                    new RunsInThreads<>(new HashMap<>());
+                return matcher.matchesSafely(RunsInThreadsTest::modify);
+            },
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -71,7 +74,8 @@ public final class RunsInThreadsTest {
      * Note: we added ClassCastException to the union of expected exceptions
      * because {@link HashMap#put(Object, Object)} is (illegally?) sometimes
      * throwing this error. See bug #22 and also
-     * https://stackoverflow.com/questions/29967401/strange-hashmap-exception-hashmapnode-cannot-be-cast-to-hashmaptreenode.
+     * https://stackoverflow.com/questions/29967401/strange-hashmap-exception
+     * -hashmapnode-cannot-be-cast-to-hashmaptreenode.
      *
      * @param map Tested map.
      * @return Return {@code true} if the map can be concurrently modified.

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.scalar.Constant;
 import org.cactoos.scalar.UncheckedScalar;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
 import org.junit.Rule;
@@ -53,21 +52,21 @@ public final class ScalarHasValueTest {
     @Test
     public void matchesAsExpectedWithString() {
         final String expected = "some text";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "doesn't match a String",
-            new UncheckedScalar<>(() -> expected),
+            () -> new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(expected)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesAsExpectedWithMatcher() {
         final String expected = "text";
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "doesn't match a Matcher",
-            new UncheckedScalar<>(() -> expected),
+            () -> new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(new IsEqual<>(expected))
-        );
+        ).affirm();
     }
 
     @Test
@@ -76,23 +75,23 @@ public final class ScalarHasValueTest {
         this.exception.expectMessage(
             new StringContains("Expected: Scalar with \"something\"")
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "missing matcher description",
-            new Constant<>("something else"),
-            new ScalarHasValue<>(new IsEqual<>("something"))
-        );
+            () -> new Constant<>("something else"),
+            new ScalarHasValue<>("something")
+        ).affirm();
     }
 
     @Test
     public void hasMismatchDescriptionForFailedTest() throws Exception {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
-            new StringContains("but: was \"actual\"")
+            new StringContains("but was: \"actual\"")
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "missing mismatch description",
-            new Constant<>("actual"),
-            new ScalarHasValue<>(new IsEqual<>("expected"))
-        );
+            () -> new Constant<>("actual"),
+            new ScalarHasValue<>("expected")
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -46,11 +45,11 @@ public final class StartsWithTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives positive result for the valid arguments",
-            new TextOf("I'm simple and I know it."),
+            () -> new TextOf("I'm simple and I know it."),
             new StartsWith("I'm simple")
-        );
+        ).affirm();
     }
 
     /**
@@ -58,14 +57,14 @@ public final class StartsWithTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives negative result for the invalid arguments",
-            new StartsWith("!").matchesSafely(
+            () -> new StartsWith("!").matchesSafely(
                 () -> "The sentence.",
                 new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -75,13 +74,15 @@ public final class StartsWithTest {
      */
     @Test
     public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new StartsWith("").matchesSafely(new TextOf("ABC"), desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new StartsWith("").matchesSafely(new TextOf("ABC"), desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text is \"ABC\"")
-        );
+        ).affirm();
     }
 
     /**
@@ -90,13 +91,15 @@ public final class StartsWithTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new StartsWith("!").describeTo(desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the description of the scenario",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new StartsWith("!").describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text starting with \"!\"")
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TeeInputHasResultTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TeeInputHasResultTest.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayOutputStream;
 import org.cactoos.io.OutputTo;
 import org.cactoos.io.TeeInput;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -40,86 +39,87 @@ import org.junit.Test;
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TeeInputHasResultTest {
 
     @Test
     public void failsIfInputDoesNotMatchExpectedValue() {
-        final TeeInput matchable = new TeeInput(
-            new TextOf("input"),
-            new OutputTo(new ByteArrayOutputStream())
-        );
-        final String expected = "expected-1";
-        final TeeInputHasResult matcher = new TeeInputHasResult(
-            expected,
-            new TextOf(expected)
-        );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher does not compare input and expected values",
-            matcher.matchesSafely(matchable),
+            () -> {
+                final TeeInput matchable = new TeeInput(
+                    new TextOf("input"),
+                    new OutputTo(new ByteArrayOutputStream())
+                );
+                final String expected = "expected-1";
+                final TeeInputHasResult matcher = new TeeInputHasResult(
+                    expected, new TextOf(expected)
+                );
+                return matcher.matchesSafely(matchable);
+            },
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     @Test
     public void describesMismatchOfInputAndExpected() {
-        final TeeInput matchable = new TeeInput(
-            new TextOf("i"),
-            new OutputTo(new ByteArrayOutputStream())
-        );
-        final TeeInputHasResult matcher = new TeeInputHasResult(
-            "e",
-            new TextOf("e")
-        );
-        final StringDescription description = new StringDescription();
-        matcher.matchesSafely(matchable);
-        matcher.describeMismatchSafely(matchable, description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Description of mismatch of input and expected incorrect",
-            description.toString(),
-            new IsEqual<>(
-                "TeeInput with result \"e\" and copied value \"e\""
-            )
-        );
+            () -> {
+                final TeeInput matchable = new TeeInput(
+                    new TextOf("i"),
+                    new OutputTo(new ByteArrayOutputStream())
+                );
+                final TeeInputHasResult matcher = new TeeInputHasResult(
+                    "e", new TextOf("e")
+                );
+                final StringDescription description = new StringDescription();
+                matcher.matchesSafely(matchable);
+                matcher.describeMismatchSafely(matchable, description);
+                return description.toString();
+            },
+            new IsEqual<>("TeeInput with result \"e\" and copied value \"e\"")
+        ).affirm();
     }
 
     @Test
     public void failsIfCopiedValueDoesNotMatchExpectedValue() {
-        final String expected = "expected-2";
-        final TeeInput matchable = new TeeInput(
-            new TextOf(expected),
-            new OutputTo(new ByteArrayOutputStream())
-        );
-        final TeeInputHasResult matcher = new TeeInputHasResult(
-            expected,
-            new TextOf("incorrect")
-        );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher does not compare copied and expected values",
-            matcher.matchesSafely(matchable),
+            () -> {
+                final String expected = "expected-2";
+                final TeeInput matchable = new TeeInput(
+                    new TextOf(expected),
+                    new OutputTo(new ByteArrayOutputStream())
+                );
+                final TeeInputHasResult matcher = new TeeInputHasResult(
+                    expected, new TextOf("incorrect")
+                );
+                return matcher.matchesSafely(matchable);
+            },
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     @Test
     public void describesMismatchOfCopiedAndExpected() {
-        final TeeInput matchable = new TeeInput(
-            new TextOf("i"),
-            new OutputTo(new ByteArrayOutputStream())
-        );
-        final TeeInputHasResult matcher = new TeeInputHasResult(
-            "i",
-            new TextOf("wrong")
-        );
-        final StringDescription description = new StringDescription();
-        matcher.matchesSafely(matchable);
-        matcher.describeMismatchSafely(matchable, description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Description of mismatch of copied and expected incorrect",
-            description.toString(),
-            new IsEqual<>(
-                "TeeInput with result \"i\" and copied value \"i\""
-            )
-        );
+            () -> {
+                final TeeInput matchable = new TeeInput(
+                    new TextOf("i"),
+                    new OutputTo(new ByteArrayOutputStream())
+                );
+                final TeeInputHasResult matcher = new TeeInputHasResult(
+                    "i", new TextOf("wrong")
+                );
+                final StringDescription description = new StringDescription();
+                matcher.matchesSafely(matchable);
+                matcher.describeMismatchSafely(matchable, description);
+                return description.toString();
+            },
+            new IsEqual<>("TeeInput with result \"i\" and copied value \"i\"")
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
@@ -31,7 +31,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.Md5DigestOf;
 import org.cactoos.text.HexOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
@@ -42,53 +41,56 @@ import org.junit.Test;
  *
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextHasStringTest {
 
     @Test
     public void hasClearDescriptionForFailedTest() throws Exception {
-        final HexOf hex = new HexOf(
-            new Md5DigestOf(
-                new InputOf("Hello World!")
-            )
-        );
-        final Description description = new StringDescription();
-        final TextHasString matcher = new TextHasString(
-            "ed076287532e86365e841e92bfc50d8c6"
-        );
-        matcher.matchesSafely(hex, description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Description is not clear ",
-            description.toString(),
+            () -> {
+                final HexOf hex = new HexOf(
+                    new Md5DigestOf(
+                        new InputOf("Hello World!")
+                    )
+                );
+                final Description description = new StringDescription();
+                final TextHasString matcher = new TextHasString(
+                    "ed076287532e86365e841e92bfc50d8c6"
+                );
+                matcher.matchesSafely(hex, description);
+                return description.toString();
+            },
             new StringContains("Text is \"ed076287532e86365e841e92bfc50d8c\"")
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesPrefix() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match text prefix",
-            new TextHasString("123").matches((Text) () -> "12345"),
+            () -> new TextHasString("123").matches((Text) () -> "12345"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesSuffix() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match text suffix",
-            new TextHasString("345").matches((Text) () -> "12345"),
+            () -> new TextHasString("345").matches((Text) () -> "12345"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesInTheMiddle() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match random substring in the middle of the text",
-            new TextHasString("234").matches((Text) () -> "12345"),
+            () -> new TextHasString("234").matches((Text) () -> "12345"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -27,7 +27,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Text;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -40,19 +39,19 @@ import org.junit.Test;
 public final class TextIsTest {
     @Test
     public void match() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match identical text",
-            new TextIs("abcde").matches((Text) () -> "abcde"),
+            () -> new TextIs("abcde").matches((Text) () -> "abcde"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void noMatch() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must not match text that is not identical",
-            new TextIs("xyz").matches((Text) () -> "abcde"),
+            () -> new TextIs("xyz").matches((Text) () -> "abcde"),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -47,13 +46,13 @@ public final class ThrowsTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The thrown exception is valid.",
             () -> {
                 throw new IllegalArgumentException("No object(s) found.");
             },
             new Throws<>("No object(s) found.", IllegalArgumentException.class)
-        );
+        ).affirm();
     }
 
     /**
@@ -61,16 +60,16 @@ public final class ThrowsTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The exception wasn't thrown.",
-            new Throws<>(
+            () -> new Throws<>(
                 "No object(s) found.",
                 IllegalArgumentException.class
             ).matchesSafely(
                 () -> "No object(s) found.", new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -80,21 +79,25 @@ public final class ThrowsTest {
      */
     @Test
     public void describeActualValues() {
-        final Description description = new StringDescription();
-        new Throws<>("NPE", Exception.class).matchesSafely(
-            () -> {
-                throw new IllegalArgumentException("No object(s) found.");
-            },
-            description
-        );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            description.toString(),
+            () -> {
+                final Description description = new StringDescription();
+                new Throws<>("NPE", Exception.class).matchesSafely(
+                    () -> {
+                        throw new IllegalArgumentException(
+                            "No object(s) found."
+                        );
+                    },
+                    description
+                );
+                return description.toString();
+            },
             new IsEqual<>(
                 "Exception has type 'java.lang.IllegalArgumentException'"
                     + " and message 'No object(s) found.'"
             )
-        );
+        ).affirm();
     }
 
     /**
@@ -103,15 +106,19 @@ public final class ThrowsTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new Throws<>("NPE", NullPointerException.class).describeTo(description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the details about expected exception",
-            description.toString(),
+            () -> {
+                final Description description = new StringDescription();
+                new Throws<>("NPE", NullPointerException.class).describeTo(
+                    description
+                );
+                return description.toString();
+            },
             new IsEqual<>(
                 "Exception has type 'java.lang.NullPointerException'"
                     + " and message 'NPE'"
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/resources/forbidden-apis.txt
+++ b/src/test/resources/forbidden-apis.txt
@@ -6,3 +6,6 @@ org.hamcrest.MatcherAssert#assertThat(java.lang.Object, org.hamcrest.Matcher)
 
 @defaultMessage Please specify failure reason
 org.junit.Assert#assertThat(java.lang.Object, org.hamcrest.Matcher)
+
+@defaultMessage Use org.llorllale.cactoos.matchers.Assertion instead of MatcherAssert
+org.hamcrest.MatcherAssert


### PR DESCRIPTION
This PR is for #52:
 - Replace all usages of MatcherAssert in favor of Assertion (in tests, javadocs)
 - Add MatcherAssert to the forbidden API
 - Fix ScalarHasValue in order to support Assertion