### PR TITLE
#52: Replace all uses of MatcherAssert.assertThat(), part 1

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
@@ -68,9 +68,6 @@ import org.hamcrest.StringDescription;
  *
  * @param <T> The type of the result returned by the operation under test
  * @since 1.0.0
- * @todo #18:30min Replace all uses of MatcherAssert.assertThat() with
- *  Assertion, and ban all overloads of the former in forbidden-apis.txt.
- *  We should also look into banning common matchers like Matchers.is(), etc.
  * @todo #18:30min Assertion relies on the operation under test to be idempotent
  *  in order to match "error matchers" such as `Throws` as expected. This may
  *  not be the case for all operations and could be a problem. Investigate if

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -37,8 +37,9 @@ import org.junit.Test;
  * Test case for {@link EndsWith}.
  *
  * @since 1.0.0
- * @todo #52/DEV Ban all overloads of the former in forbidden-apis.txt.
- *  We should also look into banning common matchers like Matchers.is(), etc.
+ * @todo #52/DEV:30min Ban all overloads of the former in forbidden-apis.txt.
+ *  We should also look into banning common static matchers like Matchers.is(),
+ *  etc.
  */
 public final class EndsWithTest {
 

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -38,6 +37,8 @@ import org.junit.Test;
  * Test case for {@link EndsWith}.
  *
  * @since 1.0.0
+ * @todo #52/DEV Ban all overloads of the former in forbidden-apis.txt.
+ *  We should also look into banning common matchers like Matchers.is(), etc.
  */
 public final class EndsWithTest {
 
@@ -46,11 +47,11 @@ public final class EndsWithTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives positive result for the valid arguments",
-            new TextOf("I'm simple and I know it."),
+            () -> new TextOf("I'm simple and I know it."),
             new EndsWith("know it.")
-        );
+        ).affirm();
     }
 
     /**
@@ -58,14 +59,14 @@ public final class EndsWithTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives negative result for the invalid arguments",
-            new EndsWith("!").matchesSafely(
+            () -> new EndsWith("!").matchesSafely(
                 () -> "The sentence.",
                 new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -75,13 +76,15 @@ public final class EndsWithTest {
      */
     @Test
     public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new EndsWith("").matchesSafely(new TextOf("ABC"), desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new EndsWith("").matchesSafely(new TextOf("ABC"), desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text is \"ABC\"")
-        );
+        ).affirm();
     }
 
     /**
@@ -90,13 +93,14 @@ public final class EndsWithTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new EndsWith("!").describeTo(desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the description of the scenario",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new EndsWith("!").describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text ending with \"!\"")
-        );
+        ).affirm();
     }
-
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
  * Test case for {@link EndsWith}.
  *
  * @since 1.0.0
- * @todo #52/DEV:30min Ban all overloads of the former in forbidden-apis.txt.
+ * @todo #52:30min Ban all overloads of the former in forbidden-apis.txt.
  *  We should also look into banning common static matchers like Matchers.is(),
  *  etc.
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
@@ -26,7 +26,6 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -39,11 +38,14 @@ import org.junit.Test;
 public final class FuncAppliesTest {
     @Test
     public void matchFuncs() {
-        final FuncApplies<Integer, Integer> matcher = new FuncApplies<>(1, 1);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Can't match equaled values",
-            matcher.matchesSafely(x -> x),
+            () -> {
+                final FuncApplies<Integer, Integer> matcher =
+                    new FuncApplies<>(1, 1);
+                return matcher.matchesSafely(x -> x);
+            },
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesMatchingTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesMatchingTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.list.ListOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -48,11 +47,11 @@ public final class HasValuesMatchingTest {
      */
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher give the positive result for the valid arguments",
-            new ListOf<>(1, 2, 3),
+            () -> new ListOf<>(1, 2, 3),
             new HasValuesMatching<>(value -> value > 1 || value == 3)
-        );
+        ).affirm();
     }
 
     /**
@@ -60,35 +59,37 @@ public final class HasValuesMatchingTest {
      */
     @Test
     public void matchSafely() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher give the negative result for the invalid arguments",
-            new HasValuesMatching<String>(
+            () -> new HasValuesMatching<String>(
                 text -> text.contains("simple")
             ).matchesSafely(
                 new ListOf<>("I'm", "short", "sentence"),
                 new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
      * Matcher prints the actual value(s) properly in case of errors.
      * The actual/expected section are using only when testing is failed and
      *  we need to explain what exactly went wrong.
-    */
+     */
     @Test
     public void describeActualValues() {
-        final Description description = new StringDescription();
-        new HasValuesMatching<Integer>(value -> value > 5)
-            .matchesSafely(new ListOf<>(1, 2, 3), description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            description.toString(),
+            () -> {
+                final Description description = new StringDescription();
+                new HasValuesMatching<Integer>(value -> value > 5)
+                    .matchesSafely(new ListOf<>(1, 2, 3), description);
+                return description.toString();
+            },
             new IsEqual<>(
                 "No any elements from [1, 2, 3] matches by the function"
             )
-        );
+        ).affirm();
     }
 
     /**
@@ -97,13 +98,15 @@ public final class HasValuesMatchingTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new HasValuesMatching<Integer>(value -> value > 5)
-            .describeTo(description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the optional description of the scenario",
-            description.toString(),
+            () -> {
+                final Description description = new StringDescription();
+                new HasValuesMatching<Integer>(value -> value > 5)
+                    .describeTo(description);
+                return description.toString();
+            },
             new IsEqual<>("The function matches at least 1 element.")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.list.ListOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -50,11 +49,11 @@ public final class HasValuesTest {
      */
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher check that [1,2,3] contains [2]",
-            new ListOf<>(1, 2, 3),
+            () -> new ListOf<>(1, 2, 3),
             new HasValues<>(2)
-        );
+        ).affirm();
     }
 
     /**
@@ -62,14 +61,14 @@ public final class HasValuesTest {
      */
     @Test
     public void matchSafely() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher check that [a,b,c,e] contains [a,b]",
-            new HasValues<>("a", "b").matchesSafely(
+            () -> new HasValues<>("a", "b").matchesSafely(
                 new ListOf<>("a", "b", "c", "e"),
                 new StringDescription()
             ),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     /**
@@ -96,13 +95,17 @@ public final class HasValuesTest {
      */
     @Test
     public void describeActualValues() {
-        final Description description = new StringDescription();
-        new HasValues<>(5).matchesSafely(new ListOf<>(1, 2, 3), description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            description.toString(),
+            () -> {
+                final Description description = new StringDescription();
+                new HasValues<>(5).matchesSafely(
+                    new ListOf<>(1, 2, 3), description
+                );
+                return description.toString();
+            },
             new IsEqual<>("<1, 2, 3>")
-        );
+        ).affirm();
     }
 
     /**
@@ -110,13 +113,15 @@ public final class HasValuesTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new HasValues<>(3, 4).describeTo(description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which should be present in the "
                 + "target iterable",
-            description.toString(),
+            () -> {
+                final Description description = new StringDescription();
+                new HasValues<>(3, 4).describeTo(description);
+                return description.toString();
+            },
             new IsEqual<>("<3, 4>")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/InputHasContentTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/InputHasContentTest.java
@@ -26,9 +26,7 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.Input;
 import org.cactoos.io.InputOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
@@ -43,21 +41,19 @@ public final class InputHasContentTest {
     @Test
     public void matchesInputContent() {
         final String text = "Hello World!";
-        final Input input = new InputOf(text);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher does not match equal values",
-            input,
+            () -> new InputOf(text),
             new InputHasContent(text)
-        );
+        ).affirm();
     }
 
     @Test
     public void failsIfContentDoesNotMatch() {
-        final Input input = new InputOf("hello");
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher matches values that are not equal",
-            input,
+            () -> new InputOf("hello"),
             new IsNot<>(new InputHasContent("world"))
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -45,10 +44,10 @@ public final class IsTrueTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives positive result for valid argument.",
-            true, new IsTrue()
-        );
+            () -> true, new IsTrue()
+        ).affirm();
     }
 
     /**
@@ -56,11 +55,11 @@ public final class IsTrueTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives negative result for invalid argument.",
-            new IsTrue().matchesSafely(false, new StringDescription()),
+            () -> new IsTrue().matchesSafely(false, new StringDescription()),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -70,13 +69,15 @@ public final class IsTrueTest {
      */
     @Test
     public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new IsTrue().matchesSafely(false, desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new IsTrue().matchesSafely(false, desc);
+                return desc.toString();
+            },
             new IsEqual<>("<false>")
-        );
+        ).affirm();
     }
 
     /**
@@ -85,12 +86,14 @@ public final class IsTrueTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new IsTrue().describeTo(desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the details about expected value",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new IsTrue().describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("<true>")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
@@ -30,7 +30,6 @@ package org.llorllale.cactoos.matchers;
 import org.cactoos.Text;
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -49,11 +48,11 @@ public final class MatchesTest {
      */
     @Test
     public void matches() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher TextIs(abc) gives positive result for Text(abc)",
-            new TextIs("abc"),
+            () -> new TextIs("abc"),
             new Matches<>(new TextOf("abc"))
-        );
+        ).affirm();
     }
 
     /**
@@ -61,11 +60,11 @@ public final class MatchesTest {
      */
     @Test
     public void matchStatus() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher TextIs(abc) gives negative result for Text(def)",
-            new Matches<Text>(() -> "def").matches(new TextIs("abc")),
+            () -> new Matches<Text>(() -> "def").matches(new TextIs("abc")),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -73,17 +72,19 @@ public final class MatchesTest {
      */
     @Test
     public void describeActual() {
-        final Description msg = new StringDescription();
-        new Matches<Text>(
-            new TextOf("expected")
-        ).matchesSafely(
-            new TextIs("actual"), msg
-        );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            msg.toString(),
+            () -> {
+                final Description msg = new StringDescription();
+                new Matches<Text>(
+                    new TextOf("expected")
+                ).matchesSafely(
+                    new TextIs("actual"), msg
+                );
+                return msg.toString();
+            },
             new IsEqual<>("Text with value \"actual\"")
-        );
+        ).affirm();
     }
 
     /**
@@ -91,12 +92,14 @@ public final class MatchesTest {
      */
     @Test
     public void describeExpected() {
-        final Description msg = new StringDescription();
-        new Matches<Text>(new TextOf("expected")).describeTo(msg);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which is expected to be present",
-            msg.toString(),
+            () -> {
+                final Description msg = new StringDescription();
+                new Matches<Text>(new TextOf("expected")).describeTo(msg);
+                return msg.toString();
+            },
             new IsEqual<>("<expected>")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/NotBlankTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/NotBlankTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -44,38 +43,38 @@ public final class NotBlankTest {
 
     @Test
     public void blank() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must not match an empty string",
-            new NotBlank().matchesSafely(
+            () -> new NotBlank().matchesSafely(
                 "", new Description.NullDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     @Test
     public void notBlank() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match a non-empty string",
-            new NotBlank().matchesSafely(
+            () -> new NotBlank().matchesSafely(
                 "-.$%", new Description.NullDescription()
             ),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void nonBlankMessage() {
         final Description desc = new StringDescription();
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match a non-empty string",
-            new NotBlank().matchesSafely("text", desc),
+            () -> new NotBlank().matchesSafely("text", desc),
             new IsEqual<>(true)
-        );
-        MatcherAssert.assertThat(
+        ).affirm();
+        new Assertion<>(
             "must describe itself in terms of the text being matched against",
-            desc.toString(),
+            desc::toString,
             new IsEqual<>("\"text\"")
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -46,9 +45,9 @@ public final class StartsWithTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives positive result for the valid arguments",
-            new TextOf("I'm simple and I know it."),
+            () -> new TextOf("I'm simple and I know it."),
             new StartsWith("I'm simple")
         );
     }
@@ -58,9 +57,9 @@ public final class StartsWithTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher gives negative result for the invalid arguments",
-            new StartsWith("!").matchesSafely(
+            () -> new StartsWith("!").matchesSafely(
                 () -> "The sentence.",
                 new StringDescription()
             ),
@@ -75,13 +74,15 @@ public final class StartsWithTest {
      */
     @Test
     public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new StartsWith("").matchesSafely(new TextOf("ABC"), desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new StartsWith("").matchesSafely(new TextOf("ABC"), desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text is \"ABC\"")
-        );
+        ).affirm();
     }
 
     /**
@@ -90,13 +91,15 @@ public final class StartsWithTest {
      */
     @Test
     public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new StartsWith("!").describeTo(desc);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the description of the scenario",
-            desc.toString(),
+            () -> {
+                final Description desc = new StringDescription();
+                new StartsWith("!").describeTo(desc);
+                return desc.toString();
+            },
             new IsEqual<>("Text starting with \"!\"")
-        );
+        ).affirm();
     }
 
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -35,8 +35,9 @@ import org.junit.Test;
  * Tests for {@link TextIs}.
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
- * @todo #52/DEV Replace all uses of MatcherAssert.assertThat() with Assertion.
- *  Ensure that tests behavior wasn't changed during this refactoring
+ * @todo #52/DEV:30min Replace all uses of MatcherAssert.assertThat() with
+ *  Assertion. Ensure that the tests behavior wasn't changed during this
+ *  refactoring.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextIsTest {

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -35,9 +35,9 @@ import org.junit.Test;
  * Tests for {@link TextIs}.
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
- * @todo #52/DEV:30min Replace all uses of MatcherAssert.assertThat() with
+ * @todo #52:30min Replace all uses of MatcherAssert.assertThat() with
  *  Assertion. Ensure that the tests behavior wasn't changed during this
- *  refactoring.
+ *  refactoring. Each test should have single Assertion statement.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextIsTest {

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -35,6 +35,8 @@ import org.junit.Test;
  * Tests for {@link TextIs}.
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @todo #52/DEV Replace all uses of MatcherAssert.assertThat() with Assertion.
+ *  Ensure that tests behavior wasn't changed during this refactoring
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextIsTest {


### PR DESCRIPTION
This PR for #52 contains following changes:
 - 1 todo for activation of `de.thetaphi:forbiddenapis` plugin in order to restrict the usage of `MatchersAssert`, `Matchers`
 - 1 todo for the second part of the changes related to the #52 as it's huge
 - For 10 files with tests, the MatcherAsssert was `replaced` in favor of `Assertion`