### PR TITLE
#53: Assertion relies on the operation under test to be idempotent

### DIFF
--- a/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
@@ -26,6 +26,7 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import org.cactoos.Text;
 import org.cactoos.text.TextOf;
 import org.junit.Test;
 
@@ -83,7 +84,7 @@ public final class AssertionTest {
      */
     @Test
     public void affirmIfErrorMatches() {
-        new Assertion<>(
+        new Assertion<Text>(
             "must affirm the assertion if the test throws the expected error",
             () -> {
                 throw new IllegalStateException("this is a test");


### PR DESCRIPTION
This PR for #53 allows Assertion does not depend on idempotent tests:
 - This problem occurred due to `Throws` matcher, therefore it was placed to separate constructor.
 - I don't like the way with the direct casting of `Throws<T>` to `Matcher<T>` but it seems to be only one way for JDK 8 considering poor generics API.