### PR TITLE
(#51) Fixed intermittent failure in RunsInThreadsTest.matchNegative

### DIFF
--- a/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
@@ -26,79 +26,111 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
-import org.hamcrest.MatcherAssert;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.cactoos.Func;
+import org.cactoos.func.RepeatedFunc;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
- * Test case for {@link org.llorllale.cactoos.matchers.RunsInThreads}.
+ * Test case for {@link RunsInThreads}.
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCoupling (2 lines)
  */
 public final class RunsInThreadsTest {
 
+    /**
+     * Twenty threads will each attempt to increment a counter 100 times with
+     * a safe function.
+     */
     @Test
     public void matchPositive() {
-        final RunsInThreads<Map<Integer, Integer>> matcher =
-            new RunsInThreads<>(new ConcurrentHashMap<>());
-        MatcherAssert.assertThat(
-            "Can't concurrently modify ConcurrentHashMap",
-            matcher.matchesSafely(RunsInThreadsTest::modify),
-            new IsEqual<>(true)
-        );
-    }
-
-    @Test
-    public void matchNegative() {
-        final RunsInThreads<Map<Integer, Integer>> matcher =
-            new RunsInThreads<>(new HashMap<>());
-        MatcherAssert.assertThat(
-            "Can concurrently modify HashMap",
-            matcher.matchesSafely(RunsInThreadsTest::modify),
-            new IsEqual<>(false)
-        );
+        final AtomicInteger counter = new AtomicInteger(0);
+        final int threads = 20;
+        final int attempts = 100;
+        new Assertion<>(
+            "must match thread-safe Func",
+            () -> new RunsInThreads<>(counter, threads),
+            new Matches<>(
+                new RepeatedFunc<>(new Safe(), attempts)
+            )
+        ).affirm();
+        new Assertion<>(
+            "counter must be incremented by all threads",
+            () -> counter.get(),
+            new IsEqual<>(threads * attempts)
+        ).affirm();
     }
 
     /**
-     * Check possibility of concurrent modification.
-     *
-     * Note: we added ClassCastException to the union of expected exceptions
-     * because {@link HashMap#put(Object, Object)} is (illegally?) sometimes
-     * throwing this error. See bug #22 and also
-     * https://stackoverflow.com/questions/29967401/strange-hashmap-exception-hashmapnode-cannot-be-cast-to-hashmaptreenode.
-     *
-     * @param map Tested map.
-     * @return Return {@code true} if the map can be concurrently modified.
+     * Twenty threads will each attempt to increment a counter 100 times with
+     * an unsafe function.
      */
-    private static boolean modify(final Map<Integer, Integer> map) {
-        boolean flag = true;
-        try {
-            for (final Map.Entry<Integer, Integer> entry : map.entrySet()) {
-                if (entry.getKey() == null || entry.getValue() == null) {
-                    flag = false;
-                    break;
-                }
-            }
-            if (flag) {
-                //@checkstyle MagicNumberCheck (1 line)
-                for (int count = 0; count < 100; ++count) {
-                    map.put(
-                        ThreadLocalRandom.current().nextInt(),
-                        ThreadLocalRandom.current().nextInt()
-                    );
-                }
-            }
-        } catch (
-            final ConcurrentModificationException | ClassCastException ignored
-        ) {
-            flag = false;
+    @Test
+    public void matchNegative() {
+        final AtomicInteger counter = new AtomicInteger(0);
+        final int threads = 20;
+        final int attempts = 100;
+        new Assertion<>(
+            "must not match Func that is not thread-safe",
+            () -> new RunsInThreads<>(counter, threads),
+            new IsNot<>(
+                new Matches<>(
+                    new RepeatedFunc<>(new Unsafe(), attempts)
+                )
+            )
+        ).affirm();
+        new Assertion<>(
+            "counter must not be incremented by all threads",
+            () -> counter.get(),
+            new IsNot<>(new IsEqual<>(threads * attempts))
+        ).affirm();
+    }
+
+    /**
+     * Guaranteed thread-safety.
+     */
+    private static class Safe implements Func<AtomicInteger, Boolean> {
+        @Override
+        public Boolean apply(final AtomicInteger input) throws Exception {
+            input.incrementAndGet();
+            return true;
         }
-        return flag;
+    }
+
+    /**
+     * Guaranteed "thread-unsafety". It only allows the first thread to
+     * increment the integer.
+     */
+    private static class Unsafe implements Func<AtomicInteger, Boolean> {
+        /**
+         * Special value indicating no thread has yet applied this func.
+         */
+        private static final String NO_THREAD = "";
+        /**
+         * Name of thread to first apply this func.
+         */
+        private final AtomicReference<String> thread = new AtomicReference<>(
+            Unsafe.NO_THREAD
+        );
+
+        @Override
+        public Boolean apply(final AtomicInteger input) throws Exception {
+            this.thread.compareAndSet(
+                Unsafe.NO_THREAD,
+                Thread.currentThread().getName()
+            );
+            final boolean applies = this.thread.get().equals(
+                Thread.currentThread().getName()
+            );
+            if (applies) {
+                input.incrementAndGet();
+            }
+            return applies;
+        }
     }
 }


### PR DESCRIPTION
#51 
Refactored tests in `RunsInThreadsTest` in order to make them predictable.