### PR TITLE
#81 Continue to replace MatchersAssert.assertThat with Assertion

### DIFF
--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -40,7 +40,7 @@ import org.junit.rules.ExpectedException;
  * Test case for {@link ScalarHasValue}.
  *
  * @since 1.0
- * @todo #52:30min Replace all uses of MatcherAssert.assertThat() with
+ * @todo #81:30min Replace all uses of MatcherAssert.assertThat() with
  *  Assertion. Ensure that the tests behavior wasn't changed during this
  *  refactoring. Each test should have single Assertion statement.
  * @checkstyle JavadocMethodCheck (500 lines)

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -40,6 +40,9 @@ import org.junit.rules.ExpectedException;
  * Test case for {@link ScalarHasValue}.
  *
  * @since 1.0
+ * @todo #52:30min Replace all uses of MatcherAssert.assertThat() with
+ *  Assertion. Ensure that the tests behavior wasn't changed during this
+ *  refactoring. Each test should have single Assertion statement.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class ScalarHasValueTest {

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -26,36 +26,32 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.Text;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import org.cactoos.text.TextOf;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
  * Tests for {@link TextIs}.
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
- * @todo #52:30min Replace all uses of MatcherAssert.assertThat() with
- *  Assertion. Ensure that the tests behavior wasn't changed during this
- *  refactoring. Each test should have single Assertion statement.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextIsTest {
     @Test
     public void match() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match identical text",
-            new TextIs("abcde").matches((Text) () -> "abcde"),
-            new IsEqual<>(true)
-        );
+            () -> new TextOf("abcde"),
+            new TextIs("abcde")
+        ).affirm();
     }
 
     @Test
     public void noMatch() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must not match text that is not identical",
-            new TextIs("xyz").matches((Text) () -> "abcde"),
-            new IsEqual<>(false)
-        );
+            () -> new TextOf("abcde"),
+            new IsNot<>(new TextIs("xyz"))
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -35,14 +35,15 @@ import org.junit.Test;
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextIsTest {
+
     @Test
     public void match() {
+        final String input = "abcde";
         new Assertion<>(
             "must match identical text",
-            () -> new TextOf("abcde"),
-            new TextIs("abcde")
+            () -> new TextOf(input),
+            new TextIs(input)
         ).affirm();
     }
 
@@ -50,7 +51,7 @@ public final class TextIsTest {
     public void noMatch() {
         new Assertion<>(
             "must not match text that is not identical",
-            () -> new TextOf("abcde"),
+            () -> new TextOf("abcd"),
             new IsNot<>(new TextIs("xyz"))
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
@@ -60,13 +60,14 @@ public final class ThrowsTest {
      */
     @Test
     public void matchNegative() {
+        final String msg = "No object(s) found.";
         new Assertion<>(
             "The exception wasn't thrown.",
             () -> new Throws<>(
-                "No object(s) found.",
+                msg,
                 IllegalArgumentException.class
             ).matchesSafely(
-                () -> "No object(s) found.", new StringDescription()
+                () -> msg, new StringDescription()
             ),
             new IsEqual<>(false)
         ).affirm();

--- a/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
@@ -28,7 +28,6 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -47,13 +46,13 @@ public final class ThrowsTest {
      */
     @Test
     public void matchPositive() {
-        MatcherAssert.assertThat(
-            "The thrown exception is valid.",
+        new Assertion<>(
+            "The thrown exception is not valid.",
             () -> {
                 throw new IllegalArgumentException("No object(s) found.");
             },
             new Throws<>("No object(s) found.", IllegalArgumentException.class)
-        );
+        ).affirm();
     }
 
     /**
@@ -61,16 +60,16 @@ public final class ThrowsTest {
      */
     @Test
     public void matchNegative() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The exception wasn't thrown.",
-            new Throws<>(
+            () -> new Throws<>(
                 "No object(s) found.",
                 IllegalArgumentException.class
             ).matchesSafely(
                 () -> "No object(s) found.", new StringDescription()
             ),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     /**
@@ -87,14 +86,14 @@ public final class ThrowsTest {
             },
             description
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the value which came for testing",
-            description.toString(),
+            description::toString,
             new IsEqual<>(
                 "Exception has type 'java.lang.IllegalArgumentException'"
                     + " and message 'No object(s) found.'"
             )
-        );
+        ).affirm();
     }
 
     /**
@@ -105,13 +104,13 @@ public final class ThrowsTest {
     public void describeExpectedValues() {
         final Description description = new StringDescription();
         new Throws<>("NPE", NullPointerException.class).describeTo(description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "The matcher print the details about expected exception",
-            description.toString(),
+            description::toString,
             new IsEqual<>(
                 "Exception has type 'java.lang.NullPointerException'"
                     + " and message 'NPE'"
             )
-        );
+        ).affirm();
     }
 }


### PR DESCRIPTION
As described in #81. All occurrences of MatchersAssert.assertThat() were replaced with Assertion in TextIsTest and ThrowsTest. Puzzle was added to continue in ScalarHasValueTest.