### PR TITLE
(#80) Removed all usages of org.hamcrest.MatcherAssert class

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
@@ -82,9 +82,6 @@ public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
     protected void describeMismatchSafely(final Scalar<T> item,
         final Description description) {
         description
-            .appendText("was ")
-            .appendValue(
-                new UncheckedScalar<>(item).value()
-            );
+            .appendValue(new UncheckedScalar<>(item).value());
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -37,9 +37,9 @@ import org.junit.Test;
  * Test case for {@link EndsWith}.
  *
  * @since 1.0.0
- * @todo #52:30min Ban all overloads of the former in forbidden-apis.txt.
- *  We should also look into banning common static matchers like Matchers.is(),
- *  etc.
+ * @todo #80:30min We should also look into banning common static matchers
+ *  like Matchers.is(), etc. Those static matchers should be added to the
+ *  forbidden-apis.txt file.
  */
 public final class EndsWithTest {
 

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.scalar.Constant;
 import org.cactoos.scalar.UncheckedScalar;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
 import org.junit.Rule;
@@ -56,46 +55,46 @@ public final class ScalarHasValueTest {
     @Test
     public void matchesAsExpectedWithString() {
         final String expected = "some text";
-        MatcherAssert.assertThat(
-            "doesn't match a String",
-            new UncheckedScalar<>(() -> expected),
+        new Assertion<>(
+            "must match with expected string",
+            () -> new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(expected)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesAsExpectedWithMatcher() {
         final String expected = "text";
-        MatcherAssert.assertThat(
-            "doesn't match a Matcher",
-            new UncheckedScalar<>(() -> expected),
+        new Assertion<>(
+            "must match a Matcher",
+            () -> new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(new IsEqual<>(expected))
-        );
+        ).affirm();
     }
 
     @Test
-    public void hasMatcherDescriptionForFailedTest() throws Exception {
+    public void hasMatcherDescriptionForFailedTest() {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
             new StringContains("Expected: Scalar with \"something\"")
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "missing matcher description",
-            new Constant<>("something else"),
+            () -> new Constant<>("something else"),
             new ScalarHasValue<>(new IsEqual<>("something"))
-        );
+        ).affirm();
     }
 
     @Test
-    public void hasMismatchDescriptionForFailedTest() throws Exception {
+    public void hasMismatchDescriptionForFailedTest() {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
-            new StringContains("but: was \"actual\"")
+            new StringContains("but was: was \"actual\"")
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "missing mismatch description",
-            new Constant<>("actual"),
+            () -> new Constant<>("actual"),
             new ScalarHasValue<>(new IsEqual<>("expected"))
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -39,9 +39,6 @@ import org.junit.rules.ExpectedException;
  * Test case for {@link ScalarHasValue}.
  *
  * @since 1.0
- * @todo #81:30min Replace all uses of MatcherAssert.assertThat() with
- *  Assertion. Ensure that the tests behavior wasn't changed during this
- *  refactoring. Each test should have single Assertion statement.
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class ScalarHasValueTest {
@@ -53,10 +50,10 @@ public final class ScalarHasValueTest {
     public final ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void matchesAsExpectedWithString() {
+    public void matchesWithExpectedString() {
         final String expected = "some text";
         new Assertion<>(
-            "must match with expected string",
+            "Must match with expected string",
             () -> new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(expected)
         ).affirm();
@@ -66,7 +63,7 @@ public final class ScalarHasValueTest {
     public void matchesAsExpectedWithMatcher() {
         final String expected = "text";
         new Assertion<>(
-            "must match a Matcher",
+            "Must match a Matcher",
             () -> new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(new IsEqual<>(expected))
         ).affirm();
@@ -79,7 +76,7 @@ public final class ScalarHasValueTest {
             new StringContains("Expected: Scalar with \"something\"")
         );
         new Assertion<>(
-            "missing matcher description",
+            "Missing matcher description",
             () -> new Constant<>("something else"),
             new ScalarHasValue<>(new IsEqual<>("something"))
         ).affirm();
@@ -89,10 +86,10 @@ public final class ScalarHasValueTest {
     public void hasMismatchDescriptionForFailedTest() {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
-            new StringContains("but was: was \"actual\"")
+            new StringContains("but was: \"actual\"")
         );
         new Assertion<>(
-            "missing mismatch description",
+            "Missing mismatch description",
             () -> new Constant<>("actual"),
             new ScalarHasValue<>(new IsEqual<>("expected"))
         ).affirm();

--- a/src/test/java/org/llorllale/cactoos/matchers/TeeInputHasResultTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TeeInputHasResultTest.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayOutputStream;
 import org.cactoos.io.OutputTo;
 import org.cactoos.io.TeeInput;
 import org.cactoos.text.TextOf;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -40,6 +39,7 @@ import org.junit.Test;
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TeeInputHasResultTest {
 
@@ -54,11 +54,11 @@ public final class TeeInputHasResultTest {
             expected,
             new TextOf(expected)
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher does not compare input and expected values",
-            matcher.matchesSafely(matchable),
+            () -> matcher.matchesSafely(matchable),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     @Test
@@ -74,13 +74,13 @@ public final class TeeInputHasResultTest {
         final StringDescription description = new StringDescription();
         matcher.matchesSafely(matchable);
         matcher.describeMismatchSafely(matchable, description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Description of mismatch of input and expected incorrect",
-            description.toString(),
+            description::toString,
             new IsEqual<>(
                 "TeeInput with result \"e\" and copied value \"e\""
             )
-        );
+        ).affirm();
     }
 
     @Test
@@ -94,11 +94,11 @@ public final class TeeInputHasResultTest {
             expected,
             new TextOf("incorrect")
         );
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Matcher does not compare copied and expected values",
-            matcher.matchesSafely(matchable),
+            () -> matcher.matchesSafely(matchable),
             new IsEqual<>(false)
-        );
+        ).affirm();
     }
 
     @Test
@@ -114,12 +114,12 @@ public final class TeeInputHasResultTest {
         final StringDescription description = new StringDescription();
         matcher.matchesSafely(matchable);
         matcher.describeMismatchSafely(matchable, description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Description of mismatch of copied and expected incorrect",
-            description.toString(),
+            description::toString,
             new IsEqual<>(
                 "TeeInput with result \"i\" and copied value \"i\""
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextHasStringTest.java
@@ -31,7 +31,6 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.Md5DigestOf;
 import org.cactoos.text.HexOf;
 import org.hamcrest.Description;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringContains;
@@ -42,6 +41,7 @@ import org.junit.Test;
  *
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class TextHasStringTest {
@@ -58,37 +58,37 @@ public final class TextHasStringTest {
             "ed076287532e86365e841e92bfc50d8c6"
         );
         matcher.matchesSafely(hex, description);
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "Description is not clear ",
-            description.toString(),
+            description::toString,
             new StringContains("Text is \"ed076287532e86365e841e92bfc50d8c\"")
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesPrefix() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match text prefix",
-            new TextHasString("123").matches((Text) () -> "12345"),
+            () -> new TextHasString("123").matches((Text) () -> "12345"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesSuffix() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match text suffix",
-            new TextHasString("345").matches((Text) () -> "12345"),
+            () -> new TextHasString("345").matches((Text) () -> "12345"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 
     @Test
     public void matchesInTheMiddle() {
-        MatcherAssert.assertThat(
+        new Assertion<>(
             "must match random substring in the middle of the text",
-            new TextHasString("234").matches((Text) () -> "12345"),
+            () -> new TextHasString("234").matches((Text) () -> "12345"),
             new IsEqual<>(true)
-        );
+        ).affirm();
     }
 }

--- a/src/test/resources/forbidden-apis.txt
+++ b/src/test/resources/forbidden-apis.txt
@@ -6,3 +6,6 @@ org.hamcrest.MatcherAssert#assertThat(java.lang.Object, org.hamcrest.Matcher)
 
 @defaultMessage Please specify failure reason
 org.junit.Assert#assertThat(java.lang.Object, org.hamcrest.Matcher)
+
+@defaultMessage Please do not use org.hamcrest.MatcherAssert class. Use org.llorllale.cactoos.matchers.Assertion instead.
+org.hamcrest.MatcherAssert


### PR DESCRIPTION
This PR is for PDD #80:
- it removes all usages of org.hamcrest.MatcherAssert class in tests
- it prohibits usage of org.hamcrest.MatcherAssert
