### PR TITLE
#74 HasSize matcher for checking Iterables size

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/HasSize.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasSize.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import org.cactoos.collection.CollectionOf;
+
+/**
+ * Matcher to check that {@link Iterable} has required size.
+ *
+ * @since 1.0.0
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class HasSize extends MatcherEnvelope<Iterable<?>> {
+
+    /**
+     * Ctor.
+     * @param size The expected size of {@link Iterable}
+     */
+    public HasSize(final Integer size) {
+        super(
+        // @checkstyle IndentationCheck (5 line)
+        input -> new CollectionOf<>(input).size() == size,
+        desc -> desc.appendText("has size ")
+            .appendValue(size),
+        (input, desc) -> desc.appendText("has size ")
+            .appendValue(new CollectionOf<>(input).size())
+        );
+    }
+}

--- a/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
@@ -29,6 +29,11 @@ package org.llorllale.cactoos.matchers;
 import org.cactoos.iterable.IterableOfBooleans;
 import org.cactoos.iterable.IterableOfInts;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
@@ -37,6 +42,7 @@ import org.junit.Test;
  *
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCoupling (2 lines)
  */
 public final class HasSizeTest {
 
@@ -64,6 +70,21 @@ public final class HasSizeTest {
             "Expected size is not 0",
             () -> new HasSize(0),
             new Matches<>(new ListOf<>())
+        ).affirm();
+    }
+
+    @Test
+    public void describesMismatch() {
+        final Description description = new StringDescription();
+        new HasSize(2).describeMismatchSafely(new ListOf<>(), description);
+        new Assertion<>(
+            "Can't describe a mismatch",
+            () -> new TextOf(description.toString()),
+            new TextIs(
+                new UncheckedText(
+                    new FormattedText("has size <%d>", 0)
+                ).asString()
+            )
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
@@ -44,8 +44,8 @@ public final class HasSizeTest {
     public void matchesIterableSize() {
         new Assertion<>(
             "Expected size doesn't match",
-            () -> new IterableOfBooleans(true, false),
-            new HasSize(2)
+            () -> new HasSize(2),
+            new Matches<>(new IterableOfBooleans(true, false))
         ).affirm();
     }
 
@@ -53,8 +53,8 @@ public final class HasSizeTest {
     public void doesNotMatchIterableSize() {
         new Assertion<>(
             "Expected size should not match",
-            () -> new IterableOfInts(1),
-            new IsNot<>(new HasSize(2))
+            () ->  new IsNot<>(new HasSize(2)),
+            new Matches<>(new IterableOfInts(1))
         ).affirm();
     }
 
@@ -62,8 +62,8 @@ public final class HasSizeTest {
     public void matchesEmptyCollection() {
         new Assertion<>(
             "Expected size is not 0",
-            ListOf<Integer>::new,
-            new HasSize(0)
+            () -> new HasSize(0),
+            new Matches<>(new ListOf<>())
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
@@ -26,9 +26,9 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import java.util.ArrayList;
 import org.cactoos.iterable.IterableOfBooleans;
 import org.cactoos.iterable.IterableOfInts;
+import org.cactoos.list.ListOf;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
@@ -62,7 +62,7 @@ public final class HasSizeTest {
     public void matchesEmptyCollection() {
         new Assertion<>(
             "Expected size is not 0",
-            ArrayList::new,
+            ListOf<Integer>::new,
             new HasSize(0)
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
@@ -26,7 +26,9 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import java.util.ArrayList;
 import org.cactoos.iterable.IterableOfBooleans;
+import org.cactoos.iterable.IterableOfInts;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
@@ -39,20 +41,29 @@ import org.junit.Test;
 public final class HasSizeTest {
 
     @Test
-    public void matches() {
+    public void matchesIterableSize() {
         new Assertion<>(
-            "Sizes are not equal",
+            "Expected size doesn't match",
             () -> new IterableOfBooleans(true, false),
             new HasSize(2)
         ).affirm();
     }
 
     @Test
-    public void doesNotMatch() {
+    public void doesNotMatchIterableSize() {
         new Assertion<>(
-            "Sizes should not be equal",
-            () -> new IterableOfBooleans(true),
+            "Expected size should not match",
+            () -> new IterableOfInts(1),
             new IsNot<>(new HasSize(2))
+        ).affirm();
+    }
+
+    @Test
+    public void matchesEmptyCollection() {
+        new Assertion<>(
+            "Expected size is not 0",
+            ArrayList::new,
+            new HasSize(0)
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import org.cactoos.iterable.IterableOfBooleans;
+import org.hamcrest.core.IsNot;
+import org.junit.Test;
+
+/**
+ * Test case for {@link HasSize}.
+ *
+ * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class HasSizeTest {
+
+    @Test
+    public void matches() {
+        new Assertion<>(
+            "Sizes are not equal",
+            () -> new IterableOfBooleans(true, false),
+            new HasSize(2)
+        ).affirm();
+    }
+
+    @Test
+    public void doesNotMatch() {
+        new Assertion<>(
+            "Sizes should not be equal",
+            () -> new IterableOfBooleans(true),
+            new IsNot<>(new HasSize(2))
+        ).affirm();
+    }
+}

--- a/src/test/java/org/llorllale/cactoos/matchers/MatcherOfTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatcherOfTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import org.junit.Test;
+
+/**
+ * Test case for {@link MatcherOf}.
+ *
+ * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class MatcherOfTest {
+
+    @Test
+    public void createsMatcherFromFunc() {
+        new Assertion<>(
+            "Funcs doesn't return the same results",
+            () -> new MatcherOf<>(x -> !x),
+            new Matches<>(false)
+        ).affirm();
+    }
+}


### PR DESCRIPTION
As described in #74, HasSize matcher was created. It encapsulates size and allows to check its value against Iterables.