### PR TITLE
(#99) Expand the scope of forbidden APIs

### DIFF
--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -37,9 +37,6 @@ import org.junit.Test;
  * Test case for {@link EndsWith}.
  *
  * @since 1.0.0
- * @todo #80:30min We should also look into banning common static matchers
- *  like Matchers.is(), etc. Those static matchers should be added to the
- *  forbidden-apis.txt file.
  */
 public final class EndsWithTest {
 

--- a/src/test/resources/forbidden-apis.txt
+++ b/src/test/resources/forbidden-apis.txt
@@ -1,11 +1,8 @@
 @defaultMessage Do not use static methods
 org.hamcrest.Matchers
 
-@defaultMessage Please specify failure reason
-org.hamcrest.MatcherAssert#assertThat(java.lang.Object, org.hamcrest.Matcher)
-
-@defaultMessage Please specify failure reason
-org.junit.Assert#assertThat(java.lang.Object, org.hamcrest.Matcher)
+@defaultMessage Please do not use org.junit.Assert class. Use org.llorllale.cactoos.matchers.Assertion instead.
+org.junit.Assert
 
 @defaultMessage Please do not use org.hamcrest.MatcherAssert class. Use org.llorllale.cactoos.matchers.Assertion instead.
 org.hamcrest.MatcherAssert


### PR DESCRIPTION
#99: there already was no usage of static methods, so I cleaned up things a bit:
- Forbid any use of Assert, Matchers and MatcherAssert
- Remove duplicates rules