### PR TITLE
(#91) Assertion now only execute test once

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
@@ -29,6 +29,7 @@ package org.llorllale.cactoos.matchers;
 import org.cactoos.Proc;
 import org.cactoos.Scalar;
 import org.cactoos.func.UncheckedProc;
+import org.cactoos.scalar.StickyScalar;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
@@ -95,6 +96,18 @@ public final class Assertion<T> {
     public Assertion(
         final String rsn, final Scalar<T> test, final Matcher<T> mtr
     ) {
+        this(rsn, new StickyScalar<>(test), mtr);
+    }
+
+    /**
+     * Ctor.
+     * @param rsn Reason for refuting this assertion
+     * @param test The behaviour to test
+     * @param mtr Matcher to test behaviour
+     */
+    private Assertion(
+        final String rsn, final StickyScalar<T> test, final Matcher<T> mtr
+    ) {
         this(
             () -> !mtr.matches(test.value()),
             new Scenario(
@@ -116,6 +129,18 @@ public final class Assertion<T> {
      */
     public Assertion(
         final String rsn, final Scalar<T> test, final Throws<T> mtr
+    ) {
+        this(rsn, new StickyScalar<>(test), mtr);
+    }
+
+    /**
+     * Ctor.
+     * @param rsn Reason for refuting this assertion
+     * @param test The behaviour to test
+     * @param mtr Matcher to test behaviour
+     */
+    private Assertion(
+        final String rsn, final StickyScalar<T> test, final Throws<T> mtr
     ) {
         this(
             () -> !mtr.matches(test),

--- a/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
@@ -26,19 +26,31 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.Text;
+import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Tests for {@link Assertion}.
  *
  * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class AssertionTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
     /**
      * Assertion can be affirmed if the operation being tested matches.
      */
@@ -112,6 +124,36 @@ public final class AssertionTest {
         new Assertion<>(
             "scalar is executing once",
             quantity::get,
+            new IsEqual<>(1)
+        ).affirm();
+    }
+
+    @Test
+    public void testIsExecutedOnlyOnce() {
+        this.exception.expect(AssertionError.class);
+        this.exception.expectMessage("but was: was <1>");
+        final Iterator<Integer> iter = new ListOf<>(1, 2).iterator();
+        new Assertion<>(
+            "Exception should say expected <2> but was: <1>",
+            iter::next,
+            new IsEqual<>(2)
+        ).affirm();
+    }
+
+    @Test
+    public void testWithThrowsIsExecutedOnlyOnce() {
+        final AtomicInteger count = new AtomicInteger(0);
+        new Assertion<Text>(
+            "must affirm the assertion if the test throws the expected error",
+            () -> {
+                count.incrementAndGet();
+                throw new IllegalStateException("this is a test");
+            },
+            new Throws<>("this is a test", IllegalStateException.class)
+        ).affirm();
+        new Assertion<>(
+            "must have executed test only once",
+            count::get,
             new IsEqual<>(1)
         ).affirm();
     }


### PR DESCRIPTION
This is for #91.

It wraps the test in a `StickyScalar` to avoid it being executed twice when it fails and its value is re-retrieved for generating the error message.

Note that some of the added tests rely on `ExpectedException` because I didn't want to use `Assertion` to test `Assertion` :)