### PR TITLE
(#88) Assertion2 to replace Assertion

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
@@ -121,11 +121,6 @@ public final class Assertion<T> {
      * @param rsn Reason for refuting this assertion
      * @param test The behaviour to test
      * @param mtr Matcher to test behaviour
-     * @todo #53:30min Avoid the overloading ctor to accept subtype.
-     *  Throws is a Matcher and thus there should be no need to give it a
-     *  special treatment. The fact that we're currently being forced to do so
-     *  smells, and might mean we may end up having to rethink these
-     *  abstractions.
      */
     public Assertion(
         final String rsn, final Scalar<T> test, final Throws<T> mtr

--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion2.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion2.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import org.cactoos.scalar.UncheckedScalar;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+/**
+ * An assertion that can be affirmed in tests.
+ * <p>
+ * <strong>Examples:</strong>
+ * <p>
+ * Testing a value:
+ * <pre>
+ * {@code
+ *     public void test() {
+ *         new Assertion2<>(
+ *             "must match the string",
+ *             new TextOf("string"),
+ *             new TextIs("string")
+ *         ).affirm();    // value is affirmed
+ *     }
+ * }
+ * </pre>
+ *
+ * Testing an error (see {@link Throws}):
+ * <pre>
+ * {@code
+ *     public void test() {
+ *         new Assertion2<>(
+ *             "must match the error",
+ *             () -> { throw new IllegalArgumentException("error msg"); },
+ *             new Throws("error msg", IllegalArgumentException.class)
+ *         ).affirm();    // error is affirmed
+ *     }
+ * }
+ * </pre>
+ *
+ * @param <T> The type of the result returned by the operation under test
+ * @since 1.0.0
+ * @todo #88:30min Phase out the original Assertion class and replace with
+ *  Assertion2 instead. When done, delete the original Assertion and rename
+ *  Assertion2 to 'Assertion'.
+ */
+public final class Assertion2<T> {
+    /**
+     * Whether this assertion is refuted.
+     */
+    private final UncheckedScalar<Boolean> refuted;
+    /**
+     * Refutation error.
+     */
+    private final UncheckedScalar<AssertionError> error;
+
+    /**
+     * Ctor.
+     * @param msg Assertive statement.
+     * @param test Object under test.
+     * @param matcher Tester.
+     */
+    public Assertion2(
+        final String msg, final T test, final Matcher<T> matcher
+    ) {
+        this.refuted = new UncheckedScalar<>(() -> !matcher.matches(test));
+        this.error = new UncheckedScalar<>(
+            () -> {
+                final Description text = new StringDescription();
+                text.appendText(msg)
+                    .appendText(String.format("%nExpected: "))
+                    .appendDescriptionOf(matcher)
+                    .appendText(String.format("%n but was: "));
+                matcher.describeMismatch(test, text);
+                return new AssertionError(text.toString());
+            }
+        );
+    }
+
+    /**
+     * Affirm this assertion.
+     * @throws AssertionError if this assertion is refuted
+     */
+    public void affirm() throws AssertionError {
+        if (this.refuted.value()) {
+            throw this.error.value();
+        }
+    }
+}

--- a/src/test/java/org/llorllale/cactoos/matchers/Assertion2Test.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/Assertion2Test.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.cactoos.text.TextOf;
+import org.hamcrest.core.IsEqual;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Tests for {@link Assertion2}.
+ *
+ * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class Assertion2Test {
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    /**
+     * Assertion can be affirmed if the operation being tested matches.
+     */
+    @Test
+    public void affirmIfResultMatches() {
+        final String expected = "abc123";
+        new Assertion2<>(
+            "must affirm the assertion if the test's result is as expected",
+            new TextOf(expected),
+            new TextIs(expected)
+        ).affirm();
+    }
+
+    /**
+     * Assertion must be refuted if the operation being tested does not
+     * match.
+     */
+    @Test
+    public void refuteIfResultDoesNotMatch() {
+        this.exception.expect(AssertionError.class);
+        this.exception.expectMessage(
+            "Text with value \"no match\"\n but was: Text is \"test\""
+        );
+        new Assertion2<>(
+            "must refute the assertion if the test's result is not as expected",
+            new TextOf("test"),
+            new TextIs("no match")
+        ).affirm();
+    }
+
+    /**
+     * Assertion cannot be affirmed if the operation being tested throws an
+     * unexpected error.
+     */
+    @Test
+    public void refuteIfErrorDoesNotMatch() {
+        this.exception.expect(IllegalStateException.class);
+        new Assertion2<>(
+            "must fail if the test throws an unexpected error",
+            () -> {
+                throw new IllegalStateException();
+            },
+            new TextIs("no match")
+        ).affirm();
+    }
+
+    /**
+     * Assertion can be affirmed if the operation being tested throws an
+     * expected error.
+     */
+    @Test
+    public void affirmIfErrorMatches() {
+        new Assertion2<>(
+            "must affirm the assertion if the test throws the expected error",
+            () -> {
+                throw new IllegalStateException("this is a test");
+            },
+            new Throws<>("this is a test", IllegalStateException.class)
+        ).affirm();
+    }
+
+    /**
+     * The scalar within Assertion executed is only once.
+     */
+    @Test
+    public void scalarIsExecutedOnce() {
+        final AtomicInteger quantity = new AtomicInteger(0);
+        new Assertion2<>(
+            "must match the exception",
+            () -> {
+                quantity.incrementAndGet();
+                throw new IllegalStateException("this is a test");
+            },
+            new Throws<>("this is a test", IllegalStateException.class)
+        ).affirm();
+        new Assertion2<>(
+            "must execute scalar only once",
+            quantity.get(),
+            new IsEqual<>(1)
+        ).affirm();
+    }
+}

--- a/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/EndsWithTest.java
@@ -45,9 +45,9 @@ public final class EndsWithTest {
      */
     @Test
     public void matchPositive() {
-        new Assertion<>(
+        new Assertion2<>(
             "The matcher gives positive result for the valid arguments",
-            () -> new TextOf("I'm simple and I know it."),
+            new TextOf("I'm simple and I know it."),
             new EndsWith("know it.")
         ).affirm();
     }
@@ -57,9 +57,9 @@ public final class EndsWithTest {
      */
     @Test
     public void matchNegative() {
-        new Assertion<>(
+        new Assertion2<>(
             "The matcher gives negative result for the invalid arguments",
-            () -> new EndsWith("!").matchesSafely(
+            new EndsWith("!").matchesSafely(
                 () -> "The sentence.",
                 new StringDescription()
             ),
@@ -74,13 +74,11 @@ public final class EndsWithTest {
      */
     @Test
     public void describeActualValues() {
-        new Assertion<>(
+        final Description desc = new StringDescription();
+        new EndsWith("").matchesSafely(new TextOf("ABC"), desc);
+        new Assertion2<>(
             "The matcher print the value which came for testing",
-            () -> {
-                final Description desc = new StringDescription();
-                new EndsWith("").matchesSafely(new TextOf("ABC"), desc);
-                return desc.toString();
-            },
+            desc.toString(),
             new IsEqual<>("Text is \"ABC\"")
         ).affirm();
     }
@@ -91,13 +89,11 @@ public final class EndsWithTest {
      */
     @Test
     public void describeExpectedValues() {
-        new Assertion<>(
+        final Description desc = new StringDescription();
+        new EndsWith("!").describeTo(desc);
+        new Assertion2<>(
             "The matcher print the description of the scenario",
-            () -> {
-                final Description desc = new StringDescription();
-                new EndsWith("!").describeTo(desc);
-                return desc.toString();
-            },
+            desc.toString(),
             new IsEqual<>("Text ending with \"!\"")
         ).affirm();
     }


### PR DESCRIPTION
PR for #88:

This is the first in a series of small steps to refactor the Assertion API:

* introduced `Assertion2` with the changes discussed [here](https://github.com/llorllale/cactoos-matchers/issues/106#issuecomment-483127231)
* Copied tests for `Assertion` into `Assertion2`
   * Note: the test `refuteIfErrorDoesNotMatch` was in error - `Matcher.assertThat()` does **not** wrap an error thrown by the object under test into an `AssertionError`. This test was slightly modified accordingly.
* Left a puzzle to phase out `Assertion` over `Assertion2`, and eventually renaming the latter to the former.