### PR TITLE
(#113) Replace remaining uses Assertion -> Assertion2

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion2.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion2.java
@@ -64,9 +64,9 @@ import org.hamcrest.StringDescription;
  *
  * @param <T> The type of the result returned by the operation under test
  * @since 1.0.0
- * @todo #110:30min Continue phasing out the original Assertion class and
- *  replacing with Assertion2 instead. When done, delete the original
- *  Assertion and rename Assertion2 to 'Assertion'.
+ * @todo #113:30min Delete the original Assertion and rename Assertion2 to
+ *  'Assertion'. Then refactor all uses of 'Assertion2' to switch back to
+ *  Assertion again.
  */
 public final class Assertion2<T> {
     /**

--- a/src/test/java/org/llorllale/cactoos/matchers/HasEntryTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasEntryTest.java
@@ -49,11 +49,11 @@ public final class HasEntryTest {
      */
     @Test
     public void matches() {
-        new Assertion<>(
+        new Assertion2<>(
             "must match an entry in the map",
-            () -> new HasEntry<>("a", 1),
+            new HasEntry<>("a", 1),
             new Matches<>(
-                new MapOf<String, Integer>(
+                new MapOf<>(
                     new MapEntry<>("a", 1),
                     new MapEntry<>("b", 2)
                 )
@@ -63,9 +63,9 @@ public final class HasEntryTest {
 
     @Test(expected = AssertionError.class)
     public void doesNotMatchAMissingEntry() {
-        new Assertion<>(
+        new Assertion2<>(
             "must not match a missing entry in the map",
-            () -> new MapOf<>(
+            new MapOf<>(
                 new MapEntry<>("a", 1),
                 new MapEntry<>("b", 2)
             ),
@@ -75,9 +75,9 @@ public final class HasEntryTest {
 
     @Test(expected = AssertionError.class)
     public void doesNotMatchAnIncorrectEntry() {
-        new Assertion<>(
+        new Assertion2<>(
             "must not match an existing entry in the map",
-            () -> new MapOf<>(
+            new MapOf<>(
                 new MapEntry<>("a", 1),
                 new MapEntry<>("b", 2)
             ),

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
@@ -49,10 +49,10 @@ public final class HasValuesTest {
      */
     @Test
     public void matches() {
-        new Assertion<>(
-            "The matcher check that [1,2,3] contains [2]",
-            () -> new ListOf<>(1, 2, 3),
-            new HasValues<>(2)
+        new Assertion2<>(
+            "matches iterable containing the given element",
+            new HasValues<>(2),
+            new Matches<>(new ListOf<>(1, 2, 3))
         ).affirm();
     }
 
@@ -61,49 +61,25 @@ public final class HasValuesTest {
      */
     @Test
     public void matchSafely() {
-        new Assertion<>(
-            "The matcher check that [a,b,c,e] contains [a,b]",
-            () -> new HasValues<>("a", "b").matchesSafely(
-                new ListOf<>("a", "b", "c", "e"),
-                new StringDescription()
-            ),
-            new IsEqual<>(true)
+        new Assertion2<>(
+            "matches iterable containing the given tuple",
+            new HasValues<>("a", "b"),
+            new Matches<>(new ListOf<>("a", "b", "c", "e"))
         ).affirm();
     }
 
     /**
      * Matcher prints the actual value(s) properly.
-     *
-     * Once test is failed the hamcrest throw the {@link AssertionError}.
-     * The error has a message with expected/actual results.
-     *
-     * This test is required to check that the result hamcrest message
-     * has proper "actual section". For example the test
-     * <pre>{@code
-     * MatcherAssert.assertThat(
-     *    new ListOf<>(1, 2, 3),
-     *    new HasValues<>(5)
-     * );
-     * }</pre> will fail with the following message
-     * <pre>{@code
-     * java.lang.AssertionError:
-     *   Expected: <5>
-     *   but: <1, 2, 3>
-     * }</pre>, where
-     *  - the "actual section" is "<1, 2, 3>"
-     *  - the "expected section" is "<5>".
      */
     @Test
     public void describeActualValues() {
-        new Assertion<>(
-            "The matcher print the value which came for testing",
-            () -> {
-                final Description description = new StringDescription();
-                new HasValues<>(5).matchesSafely(
-                    new ListOf<>(1, 2, 3), description
-                );
-                return description.toString();
-            },
+        final Description description = new StringDescription();
+        new HasValues<>(5).matchesSafely(
+            new ListOf<>(1, 2, 3), description
+        );
+        new Assertion2<>(
+            "describes the test args",
+            description.toString(),
             new IsEqual<>("<1, 2, 3>")
         ).affirm();
     }
@@ -113,14 +89,11 @@ public final class HasValuesTest {
      */
     @Test
     public void describeExpectedValues() {
-        new Assertion<>(
-            "The matcher print the value which should be present in the "
-                + "target iterable",
-            () -> {
-                final Description description = new StringDescription();
-                new HasValues<>(3, 4).describeTo(description);
-                return description.toString();
-            },
+        final Description description = new StringDescription();
+        new HasValues<>(3, 4).describeTo(description);
+        new Assertion2<>(
+            "describes the expected values",
+            description.toString(),
             new IsEqual<>("<3, 4>")
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
@@ -30,6 +30,7 @@ package org.llorllale.cactoos.matchers;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
@@ -44,9 +45,10 @@ public final class IsTrueTest {
      */
     @Test
     public void matchPositive() {
-        new Assertion<>(
-            "The matcher gives positive result for valid argument.",
-            () -> true, new IsTrue()
+        new Assertion2<>(
+            "matches 'true'",
+            new IsTrue(),
+            new Matches<>(true)
         ).affirm();
     }
 
@@ -55,10 +57,10 @@ public final class IsTrueTest {
      */
     @Test
     public void matchNegative() {
-        new Assertion<>(
-            "The matcher gives negative result for invalid argument.",
-            () -> new IsTrue().matchesSafely(false, new StringDescription()),
-            new IsEqual<>(false)
+        new Assertion2<>(
+            "mismatches 'false'",
+            new IsTrue(),
+            new IsNot<>(new Matches<>(false))
         ).affirm();
     }
 
@@ -69,13 +71,11 @@ public final class IsTrueTest {
      */
     @Test
     public void describeActualValues() {
-        new Assertion<>(
-            "The matcher print the value which came for testing",
-            () -> {
-                final Description desc = new StringDescription();
-                new IsTrue().matchesSafely(false, desc);
-                return desc.toString();
-            },
+        final Description desc = new StringDescription();
+        new IsTrue().matchesSafely(false, desc);
+        new Assertion2<>(
+            "describes the test arg",
+            desc.toString(),
             new IsEqual<>("<false>")
         ).affirm();
     }
@@ -86,13 +86,11 @@ public final class IsTrueTest {
      */
     @Test
     public void describeExpectedValues() {
-        new Assertion<>(
-            "The matcher print the details about expected value",
-            () -> {
-                final Description desc = new StringDescription();
-                new IsTrue().describeTo(desc);
-                return desc.toString();
-            },
+        final Description desc = new StringDescription();
+        new IsTrue().describeTo(desc);
+        new Assertion2<>(
+            "describes the expected value",
+            desc.toString(),
             new IsEqual<>("<true>")
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/MatcherOfTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatcherOfTest.java
@@ -26,6 +26,7 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
@@ -33,15 +34,25 @@ import org.junit.Test;
  *
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class MatcherOfTest {
 
     @Test
-    public void createsMatcherFromFunc() {
-        new Assertion<>(
-            "Funcs doesn't return the same results",
-            () -> new MatcherOf<>(x -> !x),
-            new Matches<>(false)
+    public void matchesFunc() {
+        new Assertion2<>(
+            "matches when arg satisfies the predicate",
+            new MatcherOf<>(x -> x > 5),
+            new Matches<>(10)
+        ).affirm();
+    }
+
+    @Test
+    public void mismatchesFunc() {
+        new Assertion2<>(
+            "mismatches when arg does not satisfy the predicate",
+            new MatcherOf<>(x -> x > 5),
+            new IsNot<>(new Matches<>(1))
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
  * Test case for {@link Matches}.
  *
  * @since 1.0.0
- * @checkstyle MagicNumberCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class MatchesTest {
@@ -48,9 +47,9 @@ public final class MatchesTest {
      */
     @Test
     public void matches() {
-        new Assertion<>(
+        new Assertion2<>(
             "Matcher TextIs(abc) gives positive result for Text(abc)",
-            () -> new TextIs("abc"),
+            new TextIs("abc"),
             new Matches<>(new TextOf("abc"))
         ).affirm();
     }
@@ -60,9 +59,9 @@ public final class MatchesTest {
      */
     @Test
     public void matchStatus() {
-        new Assertion<>(
+        new Assertion2<>(
             "Matcher TextIs(abc) gives negative result for Text(def)",
-            () -> new Matches<Text>(() -> "def").matches(new TextIs("abc")),
+            new Matches<Text>(() -> "def").matches(new TextIs("abc")),
             new IsEqual<>(false)
         ).affirm();
     }
@@ -72,17 +71,13 @@ public final class MatchesTest {
      */
     @Test
     public void describeActual() {
-        new Assertion<>(
-            "The matcher print the value which came for testing",
-            () -> {
-                final Description description = new StringDescription();
-                new Matches<Text>(
-                    new TextOf("expected")
-                ).matchesSafely(
-                    new TextIs("actual"), description
-                );
-                return description.toString();
-            },
+        final Description description = new StringDescription();
+        new Matches<Text>(new TextOf("expected")).matchesSafely(
+            new TextIs("actual"), description
+        );
+        new Assertion2<>(
+            "describes the matcher",
+            description.toString(),
             new IsEqual<>("Text with value \"actual\"")
         ).affirm();
     }
@@ -92,15 +87,11 @@ public final class MatchesTest {
      */
     @Test
     public void describeExpected() {
-        new Assertion<>(
-            "The matcher print the value which is expected to be present",
-            () -> {
-                final Description description = new StringDescription();
-                new Matches<Text>(
-                    new TextOf("expected")
-                ).describeTo(description);
-                return description.toString();
-            },
+        final Description description = new StringDescription();
+        new Matches<Text>(new TextOf("expected")).describeTo(description);
+        new Assertion2<>(
+            "describes the expected value",
+            description.toString(),
             new IsEqual<>("<expected>")
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -30,7 +30,6 @@ package org.llorllale.cactoos.matchers;
 import org.cactoos.scalar.Constant;
 import org.cactoos.scalar.UncheckedScalar;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.StringContains;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -52,9 +51,9 @@ public final class ScalarHasValueTest {
     @Test
     public void matchesWithExpectedString() {
         final String expected = "some text";
-        new Assertion<>(
+        new Assertion2<>(
             "Must match with expected string",
-            () -> new UncheckedScalar<>(() -> expected),
+            new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(expected)
         ).affirm();
     }
@@ -62,9 +61,9 @@ public final class ScalarHasValueTest {
     @Test
     public void matchesAsExpectedWithMatcher() {
         final String expected = "text";
-        new Assertion<>(
-            "Must match a Matcher",
-            () -> new UncheckedScalar<>(() -> expected),
+        new Assertion2<>(
+            "Must match a with the given Matcher",
+            new UncheckedScalar<>(() -> expected),
             new ScalarHasValue<>(new IsEqual<>(expected))
         ).affirm();
     }
@@ -73,25 +72,15 @@ public final class ScalarHasValueTest {
     public void hasMatcherDescriptionForFailedTest() {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
-            new StringContains("Expected: Scalar with \"something\"")
+            String.format(
+                // @checkstyle LineLength (1 line)
+                "Expected: Scalar with \"something\"%n but was: \"something else\""
+            )
         );
-        new Assertion<>(
-            "Missing matcher description",
-            () -> new Constant<>("something else"),
+        new Assertion2<>(
+            "correctly describes a mismatch",
+            new Constant<>("something else"),
             new ScalarHasValue<>(new IsEqual<>("something"))
-        ).affirm();
-    }
-
-    @Test
-    public void hasMismatchDescriptionForFailedTest() {
-        this.exception.expect(AssertionError.class);
-        this.exception.expectMessage(
-            new StringContains("but was: \"actual\"")
-        );
-        new Assertion<>(
-            "Missing mismatch description",
-            () -> new Constant<>("actual"),
-            new ScalarHasValue<>(new IsEqual<>("expected"))
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/StartsWithTest.java
@@ -31,6 +31,7 @@ import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
@@ -45,11 +46,11 @@ public final class StartsWithTest {
      */
     @Test
     public void matchPositive() {
-        new Assertion<>(
-            "The matcher gives positive result for the valid arguments",
-            () -> new TextOf("I'm simple and I know it."),
-            new StartsWith("I'm simple")
-        );
+        new Assertion2<>(
+            "matches text with prefix",
+            new StartsWith("I'm simple"),
+            new Matches<>(new TextOf("I'm simple and I know it."))
+        ).affirm();
     }
 
     /**
@@ -57,14 +58,11 @@ public final class StartsWithTest {
      */
     @Test
     public void matchNegative() {
-        new Assertion<>(
-            "The matcher gives negative result for the invalid arguments",
-            () -> new StartsWith("!").matchesSafely(
-                () -> "The sentence.",
-                new StringDescription()
-            ),
-            new IsEqual<>(false)
-        );
+        new Assertion2<>(
+            "mismatches text without the prefix",
+            new StartsWith("!"),
+            new IsNot<>(new Matches<>(new TextOf("The sentence.")))
+        ).affirm();
     }
 
     /**
@@ -74,13 +72,11 @@ public final class StartsWithTest {
      */
     @Test
     public void describeActualValues() {
-        new Assertion<>(
-            "The matcher print the value which came for testing",
-            () -> {
-                final Description desc = new StringDescription();
-                new StartsWith("").matchesSafely(new TextOf("ABC"), desc);
-                return desc.toString();
-            },
+        final Description desc = new StringDescription();
+        new StartsWith("").matchesSafely(new TextOf("ABC"), desc);
+        new Assertion2<>(
+            "describes the test arg",
+            desc.toString(),
             new IsEqual<>("Text is \"ABC\"")
         ).affirm();
     }
@@ -91,13 +87,11 @@ public final class StartsWithTest {
      */
     @Test
     public void describeExpectedValues() {
-        new Assertion<>(
-            "The matcher print the description of the scenario",
-            () -> {
-                final Description desc = new StringDescription();
-                new StartsWith("!").describeTo(desc);
-                return desc.toString();
-            },
+        final Description desc = new StringDescription();
+        new StartsWith("!").describeTo(desc);
+        new Assertion2<>(
+            "describes the expected prefix",
+            desc.toString(),
             new IsEqual<>("Text starting with \"!\"")
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextIsTest.java
@@ -40,19 +40,19 @@ public final class TextIsTest {
     @Test
     public void match() {
         final String input = "abcde";
-        new Assertion<>(
+        new Assertion2<>(
             "must match identical text",
-            () -> new TextOf(input),
-            new TextIs(input)
+            new TextIs(input),
+            new Matches<>(new TextOf(input))
         ).affirm();
     }
 
     @Test
     public void noMatch() {
-        new Assertion<>(
+        new Assertion2<>(
             "must not match text that is not identical",
-            () -> new TextOf("abcd"),
-            new IsNot<>(new TextIs("xyz"))
+            new TextIs("xyz"),
+            new IsNot<>(new Matches<>(new TextOf("abcd")))
         ).affirm();
     }
 }


### PR DESCRIPTION
PR for #113:
* Replaced all remaining uses of `Assertion` with `Assertion2`
* Refactored a few tests to use `Matches`
* Added a couple of missing tests
* Left puzzle to rename `Assertion2` back to `Assertion` (overwrite) and finish this transition