### PR TITLE
(#94) Refactor other matchers to extend MatcherEnvelope

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/FuncApplies.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/FuncApplies.java
@@ -28,9 +28,7 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Func;
 import org.cactoos.func.UncheckedFunc;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsEqual;
 
 /**
@@ -40,17 +38,8 @@ import org.hamcrest.core.IsEqual;
  * @param <Y> Type of output
  * @since 0.2
  */
-public final class FuncApplies<X, Y> extends TypeSafeMatcher<Func<X, Y>> {
-
-    /**
-     * Input of the function.
-     */
-    private final X input;
-
-    /**
-     * Matcher of the result.
-     */
-    private final Matcher<Y> matcher;
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public final class FuncApplies<X, Y> extends MatcherEnvelope<Func<X, Y>> {
 
     /**
      * Ctor.
@@ -63,25 +52,19 @@ public final class FuncApplies<X, Y> extends TypeSafeMatcher<Func<X, Y>> {
 
     /**
      * Ctor.
-     * @param inpt Input for the function
+     * @param input Input for the function
      * @param mtr Matcher of the text
      */
-    public FuncApplies(final X inpt, final Matcher<Y> mtr) {
-        super();
-        this.input = inpt;
-        this.matcher = mtr;
-    }
-
-    @Override
-    public boolean matchesSafely(final Func<X, Y> func) {
-        return this.matcher.matches(
-            new UncheckedFunc<>(func).apply(this.input)
+    public FuncApplies(final X input, final Matcher<Y> mtr) {
+        super(
+            // @checkstyle IndentationCheck (7 line)
+            func -> mtr.matches(
+                new UncheckedFunc<>(func).apply(input)
+            ),
+            desc -> desc.appendText("Func with ")
+                .appendDescriptionOf(mtr),
+            (func, desc) -> desc.appendText("Func with ")
+                .appendValue(func.apply(input))
         );
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-        description.appendText("Func with ");
-        description.appendDescriptionOf(this.matcher);
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherEnvelope.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherEnvelope.java
@@ -40,9 +40,14 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher Envelope.
  * @param <T> The type of the Matcher.
  * @since 1.0.0
- * @todo #75:30min Refactor other matchers to extend MatcherEnvelope.
+ * @todo #94:30min Refactor other matchers to extend MatcherEnvelope.
  *  If you do not know how to do it please refer to InputHasContent
  *  class as the example.
+ *
+ * @todo #94:30min Write unit tests for MatcherEnvelope.
+ *  Create MatcherEnvelopeTest class and write tests to cover the whole
+ *  functionality. Since MatcherEnvelope is abstract, create a private
+ *  nested child class and use it for tests.
  */
 public abstract class MatcherEnvelope<T> extends TypeSafeMatcher<T> {
 
@@ -58,7 +63,7 @@ public abstract class MatcherEnvelope<T> extends TypeSafeMatcher<T> {
      * @param mismatch BiProcedure generates a description for situation when an
      *  actual object does not match to the expected one
      */
-    public MatcherEnvelope(
+    protected MatcherEnvelope(
         final Func<T, Boolean> match,
         final Proc<Description> description,
         final BiProc<T, Description> mismatch
@@ -90,7 +95,7 @@ public abstract class MatcherEnvelope<T> extends TypeSafeMatcher<T> {
      * Ctor.
      * @param origin Encapsulated matcher.
      */
-    public MatcherEnvelope(final Matcher<T> origin) {
+    protected MatcherEnvelope(final Matcher<T> origin) {
         super();
         this.origin = origin;
     }

--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
@@ -30,11 +30,8 @@ import org.cactoos.Func;
 import org.cactoos.Proc;
 import org.cactoos.Text;
 import org.cactoos.func.FuncOf;
-import org.cactoos.func.UncheckedFunc;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Func as Matcher.
@@ -44,17 +41,7 @@ import org.hamcrest.TypeSafeMatcher;
  * @param <T> Type of object to match
  * @since 0.12
  */
-public final class MatcherOf<T> extends TypeSafeMatcher<T> {
-
-    /**
-     * The func.
-     */
-    private final Func<T, Boolean> func;
-
-    /**
-     * Matcher description.
-     */
-    private final UncheckedText desc;
+public final class MatcherOf<T> extends MatcherEnvelope<T> {
 
     /**
      * Ctor.
@@ -78,20 +65,13 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
      * @param description The description
      */
     public MatcherOf(final Func<T, Boolean> fnc, final Text description) {
-        super();
-        this.func = fnc;
-        this.desc = new UncheckedText(
-            new FormattedText("\"%s\"", description)
+        super(
+            // @checkstyle IndentationCheck (5 line)
+            fnc,
+            desc -> desc.appendText(
+                new FormattedText("\"%s\"", description).asString()
+            ),
+            (actual, desc) -> desc.appendValue(actual)
         );
-    }
-
-    @Override
-    public boolean matchesSafely(final T item) {
-        return new UncheckedFunc<>(this.func).apply(item);
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-        description.appendText(this.desc.asString());
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
@@ -26,7 +26,9 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.cactoos.text.JoinedText;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
@@ -35,7 +37,6 @@ import org.junit.rules.ExpectedException;
 
 /**
  * Tests for {@link Assertion}.
- *
  * @since 1.0.0
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -62,12 +63,18 @@ public final class AssertionTest {
     /**
      * Assertion must be refuted if the operation being tested does not
      * match.
+     *
+     * @throws IOException if something goes wrong.
      */
     @Test
-    public void refuteIfResultDoesNotMatch() {
+    public void refuteIfResultDoesNotMatch() throws IOException {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
-            "Text with value \"no match\"\n but was: Text is \"test\""
+            new JoinedText(
+                System.lineSeparator(),
+                "Text with value \"no match\"",
+                " but was: Text is \"test\""
+            ).asString()
         );
         new Assertion<>(
             "must refute the assertion if the test's result is not as expected",

--- a/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/FuncAppliesTest.java
@@ -27,7 +27,9 @@
 package org.llorllale.cactoos.matchers;
 
 import org.hamcrest.core.IsNot;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Test case for {@link FuncApplies}.
@@ -36,6 +38,13 @@ import org.junit.Test;
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class FuncAppliesTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
     @Test
     public void matchFuncs() {
         new Assertion<>(
@@ -53,6 +62,22 @@ public final class FuncAppliesTest {
             new FuncApplies<>(1, 1),
             // @checkstyle MagicNumber (1 line)
             new IsNot<>(new Matches<>(x -> 3 * x))
+        ).affirm();
+    }
+
+    @Test
+    public void describesMismatch() {
+        this.exception.expect(AssertionError.class);
+        this.exception.expectMessage(
+            String.format(
+                "Expected: Func with <1>%n but was: Func with <3>"
+            )
+        );
+        new Assertion<>(
+            "describes mismatch",
+            // @checkstyle MagicNumber (1 line)
+            x -> 3 * x,
+            new FuncApplies<>(1, 1)
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/MatcherOfTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatcherOfTest.java
@@ -26,8 +26,13 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.hamcrest.core.IsNot;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * Test case for {@link MatcherOf}.
@@ -37,6 +42,12 @@ import org.junit.Test;
  * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class MatcherOfTest {
+
+    /**
+     * A rule for handling an exception.
+     */
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void matchesFunc() {
@@ -53,6 +64,33 @@ public final class MatcherOfTest {
             "mismatches when arg does not satisfy the predicate",
             new MatcherOf<>(x -> x > 5),
             new IsNot<>(new Matches<>(1))
+        ).affirm();
+    }
+
+    @Test
+    public void describesMismatch() {
+        this.exception.expect(AssertionError.class);
+        this.exception.expectMessage(
+            new UncheckedText(
+                new FormattedText(
+                    // @checkstyle LineLength (1 line)
+                    "describes mismatch%nExpected: \"Must be > 5\"%n but was: <1>"
+                )
+            ).asString()
+        );
+        new Assertion<>(
+            "describes mismatch",
+            1,
+            new MatcherOf<>(x -> x > 5, new TextOf("Must be > 5"))
+        ).affirm();
+    }
+
+    @Test
+    public void matcherOfProcMatchesAnyArguments() {
+        new Assertion<>(
+            "matches any arguments when constructed from a Proc",
+            new MatcherOf<>(String::trim),
+            new Matches<>("a")
         ).affirm();
     }
 }


### PR DESCRIPTION
This is for https://github.com/llorllale/cactoos-matchers/issues/94.

In this PR:
- I refactored three matchers. There are others remaining - I updated the `@todo`.
- A test was failing on my machine (Windows) because of native line endings. Fixed it.
