### PR TITLE
(#108) Allow Throws to match by a part of an exception message

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Throws.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Throws.java
@@ -26,7 +26,9 @@
  */
 package org.llorllale.cactoos.matchers;
 
+import org.cactoos.Func;
 import org.cactoos.Scalar;
+import org.cactoos.func.UncheckedFunc;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
 import org.hamcrest.Description;
@@ -48,13 +50,28 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  * @param <T> Type of the scalar's value
  * @since 1.0.0
  * @checkstyle ProtectedMethodInFinalClassCheck (200 lines)
+ * @checkstyle MemberNameCheck (200 lines)
+ * @checkstyle ParameterNameCheck (200 lines)
+ * @todo #108:30min Refactor 'Throws' to eliminate fields with compound names.
+ *  There are two fields with compound names in this class:
+ *  'messageExpectation' and 'expectationDescription'. Compound names indicate
+ *  that the scope is too large and so cohesion too low. Create a new nested
+ *  class, maybe 'MessageExpectation', and move these fields and related
+ *  logic to this class.
  */
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.LongVariable"})
 public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
 
     /**
-     * The expected exception message.
+     * The expectation which the exception message must match.
      */
-    private final String msg;
+    private final UncheckedFunc<String, Boolean> messageExpectation;
+
+    /**
+     * The description of the message expectation to be displayed in case of
+     * mismatch.
+     */
+    private final String expectationDescription;
 
     /**
      * The expected exception type.
@@ -66,21 +83,60 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
      * @param msg The expected exception message.
      * @param type The expected exception type.
      */
-    public Throws(final String msg, final Class<? extends Exception> type) {
+    public Throws(
+        final String msg, final Class<? extends Exception> type
+    ) {
+        this(
+            type,
+            actual -> actual.equals(msg),
+            new UncheckedText(
+                new FormattedText("message '%s'", msg)
+            ).asString()
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param type The expected exception type.
+     * @param expectation The expectation which the exception message must
+     *  match.
+     */
+    public Throws(
+        final Class<? extends Exception> type,
+        final Func<String, Boolean> expectation
+    ) {
+        this(type, expectation, "expectation for message.");
+    }
+
+    /**
+     * Ctor.
+     * @param type The expected exception type.
+     * @param messageExpectation The expectation which the exception message
+     *  must match.
+     * @param expectationDescription The description of the message
+     *  expectation.
+     */
+    public Throws(
+        final Class<? extends Exception> type,
+        final Func<String, Boolean> messageExpectation,
+        final String expectationDescription
+    ) {
         super();
-        this.msg = msg;
         this.type = type;
+        this.messageExpectation = new UncheckedFunc<>(messageExpectation);
+        this.expectationDescription = expectationDescription;
     }
 
     @Override
     public void describeTo(final Description dsc) {
-        describe(dsc, this.type, this.msg);
+        Throws.describe(dsc, this.type, this.expectationDescription);
     }
 
     @Override
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    protected boolean matchesSafely(final Scalar<T> obj,
-        final Description dsc) {
+    protected boolean matchesSafely(
+        final Scalar<T> obj, final Description dsc
+    ) {
         // @checkstyle IllegalCatchCheck (20 lines)
         boolean matches;
         try {
@@ -88,13 +144,15 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
             matches = false;
             dsc.appendText("The exception wasn't thrown.");
         } catch (final Exception cause) {
-            describe(dsc, cause.getClass(), cause.getMessage());
-            if (this.type.isAssignableFrom(cause.getClass())
-                && this.msg.equals(cause.getMessage())) {
-                matches = true;
-            } else {
-                matches = false;
-            }
+            Throws.describe(
+                dsc,
+                cause.getClass(),
+                new UncheckedText(
+                    new FormattedText("message '%s'", cause.getMessage())
+                ).asString()
+            );
+            matches = this.type.isAssignableFrom(cause.getClass())
+                && this.messageExpectation.apply(cause.getMessage());
         }
         return matches;
     }
@@ -103,16 +161,20 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
      * Add information about the exception to the hamcrest result message.
      *
      * @param dsc The description of the object.
-     * @param type The exception type.
-     * @param msg The exception message.
+     * @param exception The exception type.
+     * @param messageExpectation The description of the message expectation.
+     *  expectation.
      */
-    private static void describe(final Description dsc, final Class<?> type,
-        final String msg) {
+    private static void describe(
+        final Description dsc,
+        final Class<?> exception,
+        final String messageExpectation
+    ) {
         dsc.appendText(
             new UncheckedText(
                 new FormattedText(
-                    "Exception has type '%s' and message '%s'",
-                    type.getName(), msg
+                    "Exception has type '%s' and %s",
+                    exception.getName(), messageExpectation
                 )
             ).asString()
         );

--- a/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
@@ -29,6 +29,7 @@ package org.llorllale.cactoos.matchers;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Objects;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
@@ -128,6 +129,58 @@ public final class ThrowsTest {
             new IsEqual<>(
                 "Exception has type 'java.lang.NullPointerException'"
                     + " and message 'NPE'"
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void matchesMessageExpectation() {
+        new Assertion<>(
+            "matches message expectation",
+            new Throws<>(
+                IllegalArgumentException.class,
+                msg -> msg.contains("some text")
+            ),
+            new Matches<>(
+                () -> {
+                    throw new IllegalArgumentException("some text and other");
+                }
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void doesntMatchMessageExpectation() {
+        new Assertion<>(
+            "mismatches message expectation",
+            new Throws<>(
+                IllegalArgumentException.class,
+                msg -> msg.contains("some text")
+            ),
+            new IsNot<>(
+                new Matches<>(
+                    () -> {
+                        throw new IllegalArgumentException("different text");
+                    }
+                )
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void describesMessageExpectation() {
+        final Description description = new StringDescription();
+        new Throws<>(
+            NullPointerException.class,
+            Objects::nonNull,
+            "message is whatever, just not null"
+        ).describeTo(description);
+        new Assertion<>(
+            "describes the message expectation",
+            description.toString(),
+            new IsEqual<>(
+                "Exception has type 'java.lang.NullPointerException'"
+                    + " and message is whatever, just not null"
             )
         ).affirm();
     }


### PR DESCRIPTION
This is for https://github.com/llorllale/cactoos-matchers/issues/108.

I added a message expectation predicate to `Throws`. However, there's no simple way to describe the expectation, so I also added an optional custom expectation description. If the matcher is constructed the old way, with literal expected message, it behaves just as it used to.

This made class cohesion worse, so I added a `todo` to refactor.