### PR TITLE
(#103) Updating cactoos version and removing UncheckedScalar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.31</version>
+      <version>0.41</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
@@ -26,7 +26,7 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
@@ -72,11 +72,11 @@ public final class Assertion<T> {
     /**
      * Whether this assertion is refuted.
      */
-    private final UncheckedScalar<Boolean> refuted;
+    private final Unchecked<Boolean> refuted;
     /**
      * Refutation error.
      */
-    private final UncheckedScalar<AssertionError> error;
+    private final Unchecked<AssertionError> error;
 
     /**
      * Ctor.
@@ -87,8 +87,8 @@ public final class Assertion<T> {
     public Assertion(
         final String msg, final T test, final Matcher<T> matcher
     ) {
-        this.refuted = new UncheckedScalar<>(() -> !matcher.matches(test));
-        this.error = new UncheckedScalar<>(
+        this.refuted = new Unchecked<>(() -> !matcher.matches(test));
+        this.error = new Unchecked<>(
             () -> {
                 final Description text = new StringDescription();
                 text.appendText(msg)

--- a/src/main/java/org/llorllale/cactoos/matchers/HasLines.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasLines.java
@@ -35,7 +35,7 @@ import org.cactoos.collection.CollectionOf;
 import org.cactoos.collection.Mapped;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Allows to check that text has lines considering platform-dependent line
@@ -86,7 +86,7 @@ public final class HasLines extends MatcherEnvelope<String> {
             lns,
             text -> new CollectionOf<>(
                 text.split(
-                    new UncheckedScalar<>(sep).value()
+                    new Unchecked<>(sep).value()
                 )
             )
         );

--- a/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
@@ -28,7 +28,7 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Func;
 import org.cactoos.scalar.Or;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -84,6 +84,6 @@ public final class HasValuesMatching<X> extends
                 )
             ).asString()
         );
-        return new UncheckedScalar<>(new Or(this.fnc, actual)).value();
+        return new Unchecked<>(new Or(this.fnc, actual)).value();
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/RunsInThreads.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/RunsInThreads.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.cactoos.Func;
 import org.cactoos.scalar.And;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
@@ -99,7 +99,7 @@ public final class RunsInThreads<T> extends TypeSafeMatcher<Func<T, Boolean>> {
             futures.add(service.submit(task));
         }
         latch.countDown();
-        final boolean matches = new UncheckedScalar<>(
+        final boolean matches = new Unchecked<>(
             new And(
                 (Func<Future<Boolean>, Boolean>) Future::get,
                 futures

--- a/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
@@ -27,7 +27,7 @@
 package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Scalar;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -73,7 +73,7 @@ public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
     @Override
     protected boolean matchesSafely(final Scalar<T> item) {
         return this.matcher.matches(
-            new UncheckedScalar<>(item).value()
+            new Unchecked<>(item).value()
         );
     }
 
@@ -82,6 +82,6 @@ public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
     protected void describeMismatchSafely(final Scalar<T> item,
         final Description description) {
         description
-            .appendValue(new UncheckedScalar<>(item).value());
+            .appendValue(new Unchecked<>(item).value());
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
@@ -28,9 +28,10 @@ package org.llorllale.cactoos.matchers;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -70,7 +71,7 @@ public final class AssertionTest {
     public void refuteIfResultDoesNotMatch() throws IOException {
         this.exception.expect(AssertionError.class);
         this.exception.expectMessage(
-            new JoinedText(
+            new Joined(
                 System.lineSeparator(),
                 "Text with value \"no match\"",
                 " but was: Text is \"test\""
@@ -89,7 +90,9 @@ public final class AssertionTest {
      */
     @Test
     public void refuteIfErrorDoesNotMatch() {
-        this.exception.expect(IllegalStateException.class);
+        this.exception.expectCause(
+            IsInstanceOf.instanceOf(IllegalStateException.class)
+        );
         new Assertion<>(
             "must fail if the test throws an unexpected error",
             () -> {

--- a/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/RunsInThreadsTest.java
@@ -29,7 +29,7 @@ package org.llorllale.cactoos.matchers;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.cactoos.Func;
-import org.cactoos.func.RepeatedFunc;
+import org.cactoos.func.Repeated;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
@@ -55,7 +55,7 @@ public final class RunsInThreadsTest {
         new Assertion<>(
             "matches the thread-safe Func",
             new RunsInThreads<>(counter, threads),
-            new Matches<>(new RepeatedFunc<>(new Safe(), attempts))
+            new Matches<>(new Repeated<>(new Safe(), attempts))
         ).affirm();
         new Assertion<>(
             "counter must be incremented by all threads",
@@ -78,7 +78,7 @@ public final class RunsInThreadsTest {
             new RunsInThreads<>(counter, threads),
             new IsNot<>(
                 new Matches<>(
-                    new RepeatedFunc<>(new Unsafe(), attempts)
+                    new Repeated<>(new Unsafe(), attempts)
                 )
             )
         ).affirm();

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -28,7 +28,7 @@
 package org.llorllale.cactoos.matchers;
 
 import org.cactoos.scalar.Constant;
-import org.cactoos.scalar.UncheckedScalar;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,7 +53,7 @@ public final class ScalarHasValueTest {
         final String expected = "some text";
         new Assertion<>(
             "Must match with expected string",
-            new UncheckedScalar<>(() -> expected),
+            new Unchecked<>(() -> expected),
             new ScalarHasValue<>(expected)
         ).affirm();
     }
@@ -63,7 +63,7 @@ public final class ScalarHasValueTest {
         final String expected = "text";
         new Assertion<>(
             "Must match a with the given Matcher",
-            new UncheckedScalar<>(() -> expected),
+            new Unchecked<>(() -> expected),
             new ScalarHasValue<>(new IsEqual<>(expected))
         ).affirm();
     }


### PR DESCRIPTION
* Updating cactoos to 0.41
* Replacing UncheckedScalar with Unchecked
* Replacing JoinedText with Joined
* Replacing RepeatedFunc with Repeated
* Editing test refuteIfErrorDoesNotMatch to fit new code (now IllegalStateException is wrapped in RuntimeException)