### PR TITLE
(#119) Throws matcher now takes a message matcher

### DIFF
--- a/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ThrowsTest.java
@@ -127,7 +127,34 @@ public final class ThrowsTest {
             description.toString(),
             new IsEqual<>(
                 "Exception has type 'java.lang.NullPointerException'"
-                    + " and message 'NPE'"
+                    + " and message matches \"NPE\""
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void noMessageMatchesException() {
+        new Assertion<>(
+            "must match if message is not present",
+            new Throws<>(IllegalArgumentException.class),
+            new Matches<>(
+                () -> {
+                    throw new IllegalArgumentException("No object(s) found.");
+                }
+            )
+        ).affirm();
+    }
+
+    @Test
+    public void describeExpectedValuesNoMessage() {
+        final Description description = new StringDescription();
+        new Throws<>(NullPointerException.class).describeTo(description);
+        new Assertion<>(
+            "describes the expected exception",
+            description.toString(),
+            new IsEqual<>(
+                "Exception has type 'java.lang.NullPointerException'"
+                    + " and message matches ANYTHING"
             )
         ).affirm();
     }


### PR DESCRIPTION
This is for #119.

I went with making message a `Matcher` so that we can match messages in anyway we want, including without any message.