### PR TITLE
(#120) IsBlank, IsTrue and ScalarHasValue extends MatcherEnvelope

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/IsBlank.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/IsBlank.java
@@ -26,26 +26,21 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
 /**
- * The matcher to check that text is not empty.
+ * The matcher to check that text is empty.
  *
  * @since 1.0.0
- * @checkstyle ProtectedMethodInFinalClassCheck (100 lines)
  */
-public final class IsBlank extends TypeSafeDiagnosingMatcher<String> {
-
-    @Override
-    public void describeTo(final Description desc) {
-        desc.appendText("is blank");
-    }
-
-    @Override
-    protected boolean matchesSafely(final String text,
-        final Description desc) {
-        desc.appendValue(text);
-        return text.trim().isEmpty();
+public final class IsBlank extends MatcherEnvelope<String> {
+    /**
+     * Ctor.
+     */
+    public IsBlank() {
+        super(
+            // @checkstyle IndentationCheck (3 line)
+            text -> text.trim().isEmpty(),
+            desc -> desc.appendText("is blank"),
+            (text, desc) -> desc.appendValue(text)
+        );
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/IsTrue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/IsTrue.java
@@ -26,28 +26,21 @@
  */
 package org.llorllale.cactoos.matchers;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
 /**
  * Matches if a boolean is <em>true</em>.
  *
  * @since 1.0.0
- * @checkstyle ProtectedMethodInFinalClassCheck (100 lines)
  */
-public final class IsTrue extends TypeSafeDiagnosingMatcher<Boolean> {
-
-    @Override
-    public void describeTo(final Description desc) {
-        desc.appendValue(true);
+public final class IsTrue extends MatcherEnvelope<Boolean> {
+    /**
+     * Ctor.
+     */
+    public IsTrue() {
+        super(
+            // @checkstyle IndentationCheck (3 line)
+            bool -> bool,
+            desc -> desc.appendValue(true),
+            (bool, desc) -> desc.appendValue(bool)
+        );
     }
-
-    @Override
-    protected boolean matchesSafely(
-        final Boolean actual, final Description desc
-    ) {
-        desc.appendValue(actual);
-        return actual;
-    }
-
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherEnvelope.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherEnvelope.java
@@ -40,7 +40,7 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher Envelope.
  * @param <T> The type of the Matcher.
  * @since 1.0.0
- * @todo #94:30min Refactor other matchers to extend MatcherEnvelope.
+ * @todo #120:30min Refactor other matchers to extend MatcherEnvelope.
  *  If you do not know how to do it please refer to InputHasContent
  *  class as the example.
  *

--- a/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
@@ -27,10 +27,7 @@
 package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Scalar;
-import org.cactoos.scalar.Unchecked;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsEqual;
 
 /**
@@ -39,12 +36,7 @@ import org.hamcrest.core.IsEqual;
  * @param <T> Type of result
  * @since 0.2
  */
-public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
-
-    /**
-     * Matcher of the value.
-     */
-    private final Matcher<T> matcher;
+public final class ScalarHasValue<T> extends MatcherEnvelope<Scalar<T>> {
 
     /**
      * Ctor.
@@ -56,32 +48,14 @@ public final class ScalarHasValue<T> extends TypeSafeMatcher<Scalar<T>> {
 
     /**
      * Ctor.
-     * @param mtr Matcher of the text
+     * @param mtr Matcher of the value
      */
     public ScalarHasValue(final Matcher<T> mtr) {
-        super();
-        this.matcher = mtr;
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-        description.appendText("Scalar with ");
-        description.appendDescriptionOf(this.matcher);
-    }
-
-    // @checkstyle ProtectedMethodInFinalClassCheck (1 line)
-    @Override
-    protected boolean matchesSafely(final Scalar<T> item) {
-        return this.matcher.matches(
-            new Unchecked<>(item).value()
+        super(
+            // @checkstyle IndentationCheck (3 line)
+            scalar -> mtr.matches(scalar.value()),
+            desc -> desc.appendText("Scalar with ").appendDescriptionOf(mtr),
+            (scalar, desc) -> desc.appendValue(scalar.value())
         );
-    }
-
-    // @checkstyle ProtectedMethodInFinalClassCheck (1 line)
-    @Override
-    protected void describeMismatchSafely(final Scalar<T> item,
-        final Description description) {
-        description
-            .appendValue(new Unchecked<>(item).value());
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/Throws.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Throws.java
@@ -61,13 +61,13 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
     /**
      * The expected exception type.
      */
-    private final Class<? extends Exception> type;
+    private final Class<? extends Throwable> type;
 
     /**
      * Ctor.
      * @param type The expected exception type.
      */
-    public Throws(final Class<? extends Exception> type) {
+    public Throws(final Class<? extends Throwable> type) {
         this(new IsAnything<>(), type);
     }
 
@@ -76,7 +76,7 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
      * @param msg The expected exception message.
      * @param type The expected exception type.
      */
-    public Throws(final String msg, final Class<? extends Exception> type) {
+    public Throws(final String msg, final Class<? extends Throwable> type) {
         this(new IsEqual<>(msg), type);
     }
 
@@ -87,7 +87,7 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
      */
     public Throws(
         final Matcher<String> msg,
-        final Class<? extends Exception> type
+        final Class<? extends Throwable> type
     ) {
         super();
         this.msg = msg;
@@ -104,7 +104,9 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings(
+        { "PMD.AvoidCatchingGenericException", "PMD.AvoidCatchingThrowable" }
+    )
     protected boolean matchesSafely(final Scalar<T> obj,
         final Description dsc) {
         // @checkstyle IllegalCatchCheck (20 lines)
@@ -113,7 +115,7 @@ public final class Throws<T> extends TypeSafeDiagnosingMatcher<Scalar<T>> {
             obj.value();
             matches = false;
             dsc.appendText("The exception wasn't thrown.");
-        } catch (final Exception cause) {
+        } catch (final Throwable cause) {
             dsc
                 .appendText("Exception has type '")
                 .appendText(cause.getClass().getName())

--- a/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsTrueTest.java
@@ -27,9 +27,8 @@
 
 package org.llorllale.cactoos.matchers;
 
-import org.hamcrest.Description;
-import org.hamcrest.StringDescription;
-import org.hamcrest.core.IsEqual;
+import java.io.IOException;
+import org.cactoos.text.Joined;
 import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
@@ -37,6 +36,7 @@ import org.junit.Test;
  * Test case for {@link IsTrue}.
  *
  * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
 public final class IsTrueTest {
 
@@ -64,34 +64,23 @@ public final class IsTrueTest {
         ).affirm();
     }
 
-    /**
-     * Matcher prints the actual value(s) properly in case of errors.
-     * The actual/expected section are using only when testing is failed and
-     *  we need to explain what exactly went wrong.
-     */
     @Test
-    public void describeActualValues() {
-        final Description desc = new StringDescription();
-        new IsTrue().matchesSafely(false, desc);
+    public void describesCorrectly() throws IOException {
         new Assertion<>(
-            "describes the test arg",
-            desc.toString(),
-            new IsEqual<>("<false>")
-        ).affirm();
-    }
-
-    /**
-     * Matcher prints the expected value(s) properly.
-     * The user has the ability to specify the description for the function.
-     */
-    @Test
-    public void describeExpectedValues() {
-        final Description desc = new StringDescription();
-        new IsTrue().describeTo(desc);
-        new Assertion<>(
-            "describes the expected value",
-            desc.toString(),
-            new IsEqual<>("<true>")
+            "must throw an exception that describes the values",
+            () -> {
+                new Assertion<>("", false, new IsTrue()).affirm();
+                return true;
+            },
+            new Throws<>(
+                new Joined(
+                    "\n",
+                    "",
+                    "Expected: <true>",
+                    " but was: <false>"
+                ).asString(),
+                AssertionError.class
+            )
         ).affirm();
     }
 }


### PR DESCRIPTION
This is for #120.

I had to rewrite one test to check `IsTrue` description in case of mismatch and widen the types of exceptions that `Throws` can retrieve because of it.