### PR TITLE
(#129) Convert more matchers to MatcherEnvelope

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/HasValues.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValues.java
@@ -29,8 +29,6 @@ package org.llorllale.cactoos.matchers;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * Matcher to check that {@link Iterable} has particular elements.
@@ -44,15 +42,8 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * @param <X> Type of item.
  * @since 1.0.0
- * @checkstyle ProtectedMethodInFinalClassCheck (200 lines)
  */
-public final class HasValues<X> extends TypeSafeDiagnosingMatcher<Iterable<X>> {
-
-    /**
-     * The expected values within the collection.
-     */
-    private final Iterable<X> expected;
-
+public final class HasValues<X> extends MatcherEnvelope<Iterable<X>> {
     /**
      * Ctor.
      * @param expected The expected values within unit test.
@@ -67,19 +58,12 @@ public final class HasValues<X> extends TypeSafeDiagnosingMatcher<Iterable<X>> {
      * @param expected The expected values within unit test.
      */
     public HasValues(final Iterable<X> expected) {
-        super();
-        this.expected = expected;
-    }
-
-    @Override
-    public void describeTo(final Description dsc) {
-        dsc.appendValue(new TextOf(this.expected));
-    }
-
-    @Override
-    protected boolean matchesSafely(final Iterable<X> actual,
-        final Description dsc) {
-        dsc.appendValue(new TextOf(actual));
-        return new ListOf<>(actual).containsAll(new ListOf<>(this.expected));
+        super(
+            // @checkstyle IndentationCheck (4 line)
+            actual -> new ListOf<>(actual).containsAll(new ListOf<>(expected)),
+            desc -> desc.appendText("contains ")
+                .appendValue(new TextOf(expected)),
+            (actual, desc) -> desc.appendValue(new TextOf(actual))
+        );
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValuesMatching.java
@@ -28,12 +28,8 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Func;
 import org.cactoos.scalar.Or;
-import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * Matcher to check that {@link Iterable} has elements matched by particular
@@ -48,42 +44,24 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *
  * @param <X> Type of item.
  * @since 1.0.0
- * @checkstyle ProtectedMethodInFinalClassCheck (200 lines)
  */
-public final class HasValuesMatching<X> extends
-    TypeSafeDiagnosingMatcher<Iterable<X>> {
-
-    /**
-     * The function to match at least one element within the {@link Iterable}.
-     */
-    private final Func<X, Boolean> fnc;
-
+public final class HasValuesMatching<X> extends MatcherEnvelope<Iterable<X>> {
     /**
      * Ctor.
      * @param fnc The function to match at least one element within the
      *  {@link Iterable}.
      */
     public HasValuesMatching(final Func<X, Boolean> fnc) {
-        super();
-        this.fnc = fnc;
-    }
-
-    @Override
-    public void describeTo(final Description dsc) {
-        dsc.appendText("The function matches at least 1 element.");
-    }
-
-    @Override
-    protected boolean matchesSafely(final Iterable<X> actual,
-        final Description dsc) {
-        dsc.appendText(
-            new UncheckedText(
+        super(
+            // @checkstyle IndentationCheck (7 line)
+            actual -> new Or(fnc, actual).value(),
+            desc -> desc.appendText("The function matches at least 1 element."),
+            (actual, desc) -> desc.appendText(
                 new FormattedText(
                     "No any elements from [%s] matches by the function",
                     new TextOf(actual)
-                )
-            ).asString()
+                ).asString()
+            )
         );
-        return new Unchecked<>(new Or(this.fnc, actual)).value();
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherEnvelope.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherEnvelope.java
@@ -40,7 +40,7 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher Envelope.
  * @param <T> The type of the Matcher.
  * @since 1.0.0
- * @todo #120:30min Refactor other matchers to extend MatcherEnvelope.
+ * @todo #129:30min Refactor other matchers to extend MatcherEnvelope.
  *  If you do not know how to do it please refer to InputHasContent
  *  class as the example.
  */

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesMatchingTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesMatchingTest.java
@@ -27,16 +27,16 @@
 
 package org.llorllale.cactoos.matchers;
 
+import java.io.IOException;
 import org.cactoos.list.ListOf;
-import org.hamcrest.Description;
-import org.hamcrest.StringDescription;
-import org.hamcrest.core.IsEqual;
+import org.cactoos.text.Joined;
 import org.junit.Test;
 
 /**
  * Test case for {@link HasValuesMatching}.
  *
  * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
  */
 public final class HasValuesMatchingTest {
@@ -53,55 +53,28 @@ public final class HasValuesMatchingTest {
         ).affirm();
     }
 
-    /**
-     * Give the negative testing result for the invalid arguments.
-     */
     @Test
-    public void matchSafely() {
+    public void mismatches() throws IOException {
         new Assertion<>(
-            "does not match iterable with no elements that satisfy predicate",
-            new HasValuesMatching<String>(
-                text -> text.contains("simple")
-            ).matchesSafely(
-                new ListOf<>("I'm", "short", "sentence"),
-                new StringDescription()
-            ),
-            new IsEqual<>(false)
-        ).affirm();
-    }
-
-    /**
-     * Matcher prints the actual value(s) properly in case of errors.
-     * The actual/expected section are using only when testing is failed and
-     *  we need to explain what exactly went wrong.
-     */
-    @Test
-    public void describeActualValues() {
-        final Description description = new StringDescription();
-        new HasValuesMatching<Integer>(value -> value > 5)
-            .matchesSafely(new ListOf<>(1, 2, 3), description);
-        new Assertion<>(
-            "includes the iterable's elements in description of mismatch",
-            description.toString(),
-            new IsEqual<>(
-                "No any elements from [1, 2, 3] matches by the function"
+            "must throw an exception that describes the values",
+            () -> {
+                new Assertion<>(
+                    "",
+                    new ListOf<>(1, 2, 3),
+                    new HasValuesMatching<>(value -> value > 5)
+                ).affirm();
+                return true;
+            },
+            new Throws<>(
+                new Joined(
+                    "\n",
+                    "",
+                    "Expected: The function matches at least 1 element.",
+                    // @checkstyle LineLengthCheck (1 line)
+                    " but was: No any elements from [1, 2, 3] matches by the function"
+                ).asString(),
+                AssertionError.class
             )
-        ).affirm();
-    }
-
-    /**
-     * Matcher prints the expected value(s) properly.
-     * The user has the ability to specify the description for the function.
-     */
-    @Test
-    public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new HasValuesMatching<Integer>(value -> value > 5)
-            .describeTo(description);
-        new Assertion<>(
-            "prints the optional description of the scenario upon a match",
-            description.toString(),
-            new IsEqual<>("The function matches at least 1 element.")
         ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValuesTest.java
@@ -27,19 +27,17 @@
 
 package org.llorllale.cactoos.matchers;
 
+import java.io.IOException;
 import org.cactoos.list.ListOf;
-import org.hamcrest.Description;
-import org.hamcrest.StringDescription;
-import org.hamcrest.core.IsEqual;
+import org.cactoos.text.Joined;
 import org.junit.Test;
 
 /**
  * Test case for{@link HasValues}.
  *
  * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)
- * @checkstyle RegexpSinglelineCheck (500 lines)
- * @checkstyle StringLiteralsConcatenationCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class HasValuesTest {
@@ -68,33 +66,27 @@ public final class HasValuesTest {
         ).affirm();
     }
 
-    /**
-     * Matcher prints the actual value(s) properly.
-     */
     @Test
-    public void describeActualValues() {
-        final Description description = new StringDescription();
-        new HasValues<>(5).matchesSafely(
-            new ListOf<>(1, 2, 3), description
-        );
+    public void mismatches() throws IOException {
         new Assertion<>(
-            "describes the test args",
-            description.toString(),
-            new IsEqual<>("<1, 2, 3>")
-        ).affirm();
-    }
-
-    /**
-     * Matcher prints the expected value(s) properly.
-     */
-    @Test
-    public void describeExpectedValues() {
-        final Description description = new StringDescription();
-        new HasValues<>(3, 4).describeTo(description);
-        new Assertion<>(
-            "describes the expected values",
-            description.toString(),
-            new IsEqual<>("<3, 4>")
+            "must throw an exception that describes the values",
+            () -> {
+                new Assertion<>(
+                    "",
+                    new ListOf<>(1, 2, 3),
+                    new HasValues<>(5)
+                ).affirm();
+                return true;
+            },
+            new Throws<>(
+                new Joined(
+                    "\n",
+                    "",
+                    "Expected: contains <5>",
+                    " but was: <1, 2, 3>"
+                ).asString(),
+                AssertionError.class
+            )
         ).affirm();
     }
 }


### PR DESCRIPTION
This is for #129. I just had to rewrite some tests because the exposed interface of the matcher changed (as expected).