### PR TITLE
(#132) TextMatcherEnvelope should call `asString()` only once at all

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/TextMatcherEnvelope.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/TextMatcherEnvelope.java
@@ -27,6 +27,7 @@
 package org.llorllale.cactoos.matchers;
 
 import org.cactoos.Text;
+import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -89,10 +90,9 @@ public abstract class TextMatcherEnvelope extends
     @Override
     protected final boolean matchesSafely(final Text text,
         final Description desc) {
-        desc.appendText(this.actual).appendValue(
-            new UncheckedText(text).asString()
-        );
-        return this.matcher.matches(text);
+        final String txt = new UncheckedText(text).asString();
+        desc.appendText(this.actual).appendValue(txt);
+        return this.matcher.matches(new TextOf(txt));
     }
 
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/TextMatcherEnvelopeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/TextMatcherEnvelopeTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import java.io.StringReader;
+import org.cactoos.Text;
+import org.cactoos.text.TextOf;
+import org.junit.Test;
+
+/**
+ * Tests for {@link TextMatcherEnvelope}.
+ * @since 1.0.0
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle JavadocTypeCheck (500 lines)
+ */
+public final class TextMatcherEnvelopeTest {
+
+    @Test
+    public void matchesAReadOnceInput() {
+        final String input = "aaaa";
+        new Assertion<>(
+            "must match on an input that can be read only once",
+            new TextEquals(input),
+            new Matches<>(new TextOf(new StringReader(input)))
+        ).affirm();
+    }
+
+    private static final class TextEquals extends TextMatcherEnvelope {
+        TextEquals(final String txt) {
+            super(
+                new MatcherOf<>((Text text) -> txt.equals(text.asString())),
+                "Text equals to "
+            );
+        }
+    }
+}


### PR DESCRIPTION
This is for #132 

Since there are no `Sticky` implementation for `Text` in cactoos, I simply simulated it by calling `asString()` in the matches method.

The problem originally appeared because it wasn't possible to test streams with text matchers so I added a test that reflected this use case.

I'm personally not very excited about the fact that `TextEnvelope` does so much and it is hard to test and honestly a bit brittle to do things like this, but #135 covers that matter. @paulodamaso I hope you will reconsider it since it's not in scope currently :)