### PR TITLE
For #67: Implement HasProperty

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Assertion.java
@@ -67,6 +67,10 @@ import org.hamcrest.StringDescription;
  * @todo #18:30min Replace all uses of MatcherAssert.assertThat() with
  *  Assertion, and ban all overloads of the former in forbidden-apis.txt.
  *  We should also look into banning common matchers like Matchers.is(), etc.
+ * @todo #67:30min Assertion should rely on mismatch description when forming
+ *  error message (as assertThat does). Currently 'was' is being used by this
+ *  class as part of description, it causes duplication of the word with
+ *  Matchers derived from BaseMatcher, such as IsEqual.
  */
 public final class Assertion<T> {
     /**

--- a/src/main/java/org/llorllale/cactoos/matchers/HasProperty.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasProperty.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.llorllale.cactoos.matchers;
+
+import java.util.Map;
+import java.util.Properties;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+
+/**
+ * Matcher to check that {@link Properties} has particular entry.
+ *
+ * <p>Here is an example how {@link HasProperty} can be used:</p>
+ * <pre>
+ *  new Assertion<>(
+ *     "must have an entry",
+ *     new PropertiesOf<>(...),
+ *     new HasProperty<>("foo", "bar")
+ * );</pre>
+ *
+ * @since 1.0.0
+ */
+public final class HasProperty extends MatcherEnvelope<Properties> {
+
+    /**
+     * Ctor.
+     *
+     * @param key Literal key.
+     * @param value Literal value.
+     */
+    HasProperty(final String key, final String value) {
+        this(new IsEqual<>(key), new IsEqual<>(value));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param key Matcher for key.
+     * @param value Matcher for value.
+     */
+    public HasProperty(final Matcher<String> key, final Matcher<String> value) {
+        this(new IsEntry<>(key, value));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param key Literal key.
+     */
+    public HasProperty(final String key) {
+        this(new IsEntry<>(new IsEqual<>(key), new IsAnything<>()));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param entr Entry matcher.
+     */
+    private HasProperty(final Matcher<Map.Entry<String, String>> entr) {
+        super(
+            // @checkstyle IndentationCheck (10 line)
+            properties -> new HasValuesMatching<>(
+                entr::matches
+            ).matches(properties.entrySet()),
+            desc -> desc
+                .appendText("has property ")
+                .appendDescriptionOf(entr),
+            (properties, desc) -> desc
+                .appendText("has properties ")
+                .appendValue(properties)
+        );
+    }
+
+}

--- a/src/main/java/org/llorllale/cactoos/matchers/IsEntry.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/IsEntry.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.llorllale.cactoos.matchers;
+
+import java.util.Map;
+import org.cactoos.scalar.And;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsEqual;
+
+/**
+ * Matcher to check that {@link Map.Entry} has particular key and value.
+ *
+ * @param <K> Type of key
+ * @param <V> Type of value
+ * @since 1.0.0
+ */
+public final class IsEntry<K, V> extends MatcherEnvelope<Map.Entry<K, V>> {
+
+    /**
+     * Ctor.
+     *
+     * @param key Literal key.
+     * @param value Literal value.
+     */
+    public IsEntry(final K key, final V value) {
+        this(new IsEqual<>(key), new IsEqual<>(value));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param key Matcher for key.
+     * @param value Matcher for value.
+     */
+    public IsEntry(final Matcher<K> key, final Matcher<V> value) {
+        super(
+            // @checkstyle IndentationCheck (20 line)
+            entry -> new And(
+                () -> key.matches(entry.getKey()),
+                () -> value.matches(entry.getValue())
+            ).value(),
+            desc -> {
+                IsEntry.descriptionOfKey(desc).appendDescriptionOf(key);
+                IsEntry.descriptionOfValue(desc).appendDescriptionOf(value);
+            },
+            (entry, desc) -> {
+                IsEntry.descriptionOfKey(desc);
+                key.describeMismatch(entry.getKey(), desc);
+                IsEntry.descriptionOfValue(desc);
+                value.describeMismatch(entry.getValue(), desc);
+            }
+        );
+    }
+
+    /**
+     * Start describing value.
+     *
+     * @param desc Description.
+     * @return Altered description
+     */
+    private static Description descriptionOfValue(final Description desc) {
+        return desc.appendText(", value ");
+    }
+
+    /**
+     * Start describing key.
+     *
+     * @param desc Description.
+     * @return Altered description
+     */
+    private static Description descriptionOfKey(final Description desc) {
+        return desc.appendText("key ");
+    }
+}

--- a/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/ScalarHasValue.java
@@ -55,7 +55,7 @@ public final class ScalarHasValue<T> extends MatcherEnvelope<Scalar<T>> {
             // @checkstyle IndentationCheck (3 line)
             scalar -> mtr.matches(scalar.value()),
             desc -> desc.appendText("Scalar with ").appendDescriptionOf(mtr),
-            (scalar, desc) -> desc.appendValue(scalar.value())
+            (scalar, desc) -> mtr.describeMismatch(scalar.value(), desc)
         );
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
@@ -32,7 +32,6 @@ import org.cactoos.list.ListOf;
 import org.cactoos.scalar.PropertiesOf;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
-import org.hamcrest.core.IsNot;
 import org.hamcrest.text.IsEqualIgnoringCase;
 import org.junit.Test;
 
@@ -96,13 +95,23 @@ public final class HasPropertyTest {
      */
     @Test
     public void negativeMatch() {
+        final String expected =
+            "Scalar with has property key \"abc\", value \"1\"";
         new Assertion<>(
             "must mismatches 'abc=2' & 'xyz=1'",
             new ScalarHasValue<>(new HasProperty("abc", "1")),
             new AllOf<>(
                 new ListOf<Matcher<? super ScalarHasValue<Properties>>>(
-                    new IsNot<>(new Matches<>(new PropertiesOf("abc=2"))),
-                    new IsNot<>(new Matches<>(new PropertiesOf("xyz=1")))
+                    new Mismatches<>(
+                        new PropertiesOf("abc=2"),
+                        expected,
+                        "<{abc=2}>"
+                    ),
+                    new Mismatches<>(
+                        new PropertiesOf("xyz=1"),
+                        expected,
+                        "<{xyz=1}>"
+                    )
                 )
             )
         ).affirm();

--- a/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.llorllale.cactoos.matchers;
+
+import java.util.Properties;
+import org.cactoos.list.ListOf;
+import org.cactoos.scalar.PropertiesOf;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.AllOf;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.text.IsEqualIgnoringCase;
+import org.hamcrest.text.StringContainsInOrder;
+import org.junit.Test;
+
+/**
+ * Test case for {@link HasProperty}.
+ *
+ * @since 1.0.0
+ * @checkstyle ClassDataAbstractionCoupling (100 lines)
+ */
+public final class HasPropertyTest {
+
+    /**
+     * Simple positive case.
+     */
+    @Test
+    public void positiveMatch() {
+        new Assertion<>(
+            "must match 'a=1'",
+            new ScalarHasValue<>(new HasProperty("a", "1")),
+            new Matches<>(new PropertiesOf("a=1"))
+        ).affirm();
+    }
+
+    /**
+     * Simple positive case only for key.
+     */
+    @Test
+    public void positiveMachKey() {
+        new Assertion<>(
+            "must match 'b=...'",
+            new ScalarHasValue<>(new HasProperty("b")),
+            new Matches<>(new PropertiesOf("b=..."))
+        ).affirm();
+    }
+
+    /**
+     * Positive case with Matchers.
+     */
+    @Test
+    public void positiveFuzzyMatch() {
+        new Assertion<>(
+            "must match 'f=q'",
+            new ScalarHasValue<>(
+                new HasProperty(
+                    new IsEqualIgnoringCase("F"),
+                    new IsEqualIgnoringCase("Q")
+                )
+            ),
+            new AllOf<>(
+                new ListOf<Matcher<? super ScalarHasValue<Properties>>>(
+                    new Matches<>(new PropertiesOf("F=q")),
+                    new Matches<>(new PropertiesOf("f=Q")),
+                    new Matches<>(new PropertiesOf("f=q"))
+                )
+            )
+        ).affirm();
+    }
+
+    /**
+     * Negative case.
+     */
+    @Test
+    public void negativeMatch() {
+        new Assertion<>(
+            "must mismatches 'abc=2' & 'xyz=1'",
+            new ScalarHasValue<>(new HasProperty("abc", "1")),
+            new AllOf<>(
+                new ListOf<Matcher<? super ScalarHasValue<Properties>>>(
+                    new IsNot<>(new Matches<>(new PropertiesOf("abc=2"))),
+                    new IsNot<>(new Matches<>(new PropertiesOf("xyz=1")))
+                )
+            )
+        ).affirm();
+    }
+
+    /**
+     * Test for mismatch description readability.
+     *
+     * @todo #67:30m Make {@link Matcher#describeMismatch} of the original
+     *  matcher is called by {@link ScalarHasValue}.
+     *  And then adjust this test with more readable message originating
+     *  from {@link HasProperty}.
+     */
+    @Test
+    public void describesCorrectly() {
+        new Assertion<>(
+            "must throw an exception that describes the properties",
+            () -> {
+                new Assertion<>(
+                    "",
+                    new PropertiesOf("b=2"),
+                    new ScalarHasValue<>(new HasProperty("c", "3"))
+                ).affirm();
+                return true;
+            },
+            new Throws<>(
+                new StringContainsInOrder(
+                    new ListOf<>(
+                        "Expected: Scalar with ",
+                        "has property key \"c\", value \"3\"",
+                        " but was: <{b=2}>"
+                    )
+                ),
+                AssertionError.class
+            )
+        ).affirm();
+    }
+}
+

--- a/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
@@ -105,12 +105,12 @@ public final class HasPropertyTest {
                     new Mismatches<>(
                         new PropertiesOf("abc=2"),
                         expected,
-                        "<{abc=2}>"
+                        "has properties <{abc=2}>"
                     ),
                     new Mismatches<>(
                         new PropertiesOf("xyz=1"),
                         expected,
-                        "<{xyz=1}>"
+                        "has properties <{xyz=1}>"
                     )
                 )
             )
@@ -133,7 +133,7 @@ public final class HasPropertyTest {
             new Mismatches<>(
                 new PropertiesOf("b=2"),
                 "Scalar with has property key \"c\", value \"3\"",
-                "<{b=2}>"
+                "has properties <{b=2}>"
             )
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
@@ -119,11 +119,6 @@ public final class HasPropertyTest {
 
     /**
      * Test for mismatch description readability.
-     *
-     * @todo #67:30m Make sure {@link Matcher#describeMismatch} of the original
-     *  matcher is called by {@link ScalarHasValue}.
-     *  And then adjust this test with the message originating
-     *  from {@link HasProperty}.
      */
     @Test
     public void describesCorrectly() {

--- a/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
@@ -34,7 +34,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.text.IsEqualIgnoringCase;
-import org.hamcrest.text.StringContainsInOrder;
 import org.junit.Test;
 
 /**
@@ -112,32 +111,20 @@ public final class HasPropertyTest {
     /**
      * Test for mismatch description readability.
      *
-     * @todo #67:30m Make {@link Matcher#describeMismatch} of the original
+     * @todo #67:30m Make sure {@link Matcher#describeMismatch} of the original
      *  matcher is called by {@link ScalarHasValue}.
-     *  And then adjust this test with more readable message originating
+     *  And then adjust this test with the message originating
      *  from {@link HasProperty}.
      */
     @Test
     public void describesCorrectly() {
         new Assertion<>(
-            "must throw an exception that describes the properties",
-            () -> {
-                new Assertion<>(
-                    "",
-                    new PropertiesOf("b=2"),
-                    new ScalarHasValue<>(new HasProperty("c", "3"))
-                ).affirm();
-                return true;
-            },
-            new Throws<>(
-                new StringContainsInOrder(
-                    new ListOf<>(
-                        "Expected: Scalar with ",
-                        "has property key \"c\", value \"3\"",
-                        " but was: <{b=2}>"
-                    )
-                ),
-                AssertionError.class
+            "must have a message that describes the properties",
+            new ScalarHasValue<>(new HasProperty("c", "3")),
+            new Mismatches<>(
+                new PropertiesOf("b=2"),
+                "Scalar with has property key \"c\", value \"3\"",
+                "<{b=2}>"
             )
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsEntryTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsEntryTest.java
@@ -27,11 +27,9 @@
 
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.list.ListOf;
 import org.cactoos.map.MapEntry;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.hamcrest.text.StringContainsInOrder;
 import org.junit.Test;
 
 /**
@@ -77,23 +75,12 @@ public final class IsEntryTest {
     @Test
     public void describesCorrectly() {
         new Assertion<>(
-            "must throw an exception that describes the properties",
-            () -> {
-                new Assertion<>(
-                    "",
-                    new MapEntry<>("b", "2"),
-                    new IsEntry<>("c", "3")
-                ).affirm();
-                return true;
-            },
-            new Throws<>(
-                new StringContainsInOrder(
-                    new ListOf<>(
-                        "Expected: key \"c\", value \"3\"",
-                        " but was: key was \"b\", value was \"2\""
-                    )
-                ),
-                AssertionError.class
+            "must mismatch with a description",
+            new IsEntry<>("c", "3"),
+            new Mismatches<>(
+                new MapEntry<>("b", "2"),
+                "key \"c\", value \"3\"",
+                "key was \"b\", value was \"2\""
             )
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsEntryTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsEntryTest.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.llorllale.cactoos.matchers;
+
+import org.cactoos.list.ListOf;
+import org.cactoos.map.MapEntry;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.text.StringContainsInOrder;
+import org.junit.Test;
+
+/**
+ * Test for {@link IsEntry}.
+ *
+ * @since 1.0.0
+ * @checkstyle ClassDataAbstractionCoupling (100 lines)
+ */
+public final class IsEntryTest {
+    /**
+     * Negative case.
+     */
+    @Test
+    public void doesNotMatchEntry() {
+        new Assertion<>(
+            "must not match the entry",
+            new IsEntry<>(
+                new IsEqual<>("q"),
+                new IsEqual<>("w")
+            ),
+            new IsNot<>(new Matches<>(new MapEntry<>("k", "v")))
+        ).affirm();
+    }
+
+    /**
+     * Positive case.
+     */
+    @Test
+    public void matchesEntry() {
+        new Assertion<>(
+            "must match the entry",
+            new IsEntry<>(
+                new IsEqual<>("k"),
+                new IsEqual<>("v")
+            ),
+            new Matches<>(new MapEntry<>("k", "v"))
+        ).affirm();
+    }
+
+    /**
+     * Test for mismatch description readability.
+     */
+    @Test
+    public void describesCorrectly() {
+        new Assertion<>(
+            "must throw an exception that describes the properties",
+            () -> {
+                new Assertion<>(
+                    "",
+                    new MapEntry<>("b", "2"),
+                    new IsEntry<>("c", "3")
+                ).affirm();
+                return true;
+            },
+            new Throws<>(
+                new StringContainsInOrder(
+                    new ListOf<>(
+                        "Expected: key \"c\", value \"3\"",
+                        " but was: key was \"b\", value was \"2\""
+                    )
+                ),
+                AssertionError.class
+            )
+        ).affirm();
+    }
+}

--- a/src/test/java/org/llorllale/cactoos/matchers/IsEntryTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsEntryTest.java
@@ -29,7 +29,6 @@ package org.llorllale.cactoos.matchers;
 
 import org.cactoos.map.MapEntry;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
@@ -50,7 +49,11 @@ public final class IsEntryTest {
                 new IsEqual<>("q"),
                 new IsEqual<>("w")
             ),
-            new IsNot<>(new Matches<>(new MapEntry<>("k", "v")))
+            new Mismatches<>(
+                new MapEntry<>("k", "v"),
+                "key \"q\", value \"w\"",
+                "key was \"k\", value was \"v\""
+            )
         ).affirm();
     }
 

--- a/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/ScalarHasValueTest.java
@@ -74,7 +74,7 @@ public final class ScalarHasValueTest {
         this.exception.expectMessage(
             String.format(
                 // @checkstyle LineLength (1 line)
-                "Expected: Scalar with \"something\"%n but was: \"something else\""
+                "Expected: Scalar with \"something\"%n but was: was \"something else\""
             )
         );
         new Assertion<>(


### PR DESCRIPTION
This is for #67 
Adds new matcher  `HasProperty` for `Scalar<Properties>` which uses `IsEntry` internally
Adds new matcher  `IsEntry` for `MapEntry`