### PR TITLE
(#213) Consistant naming of matcher objects

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/HasContent.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasContent.java
@@ -41,13 +41,13 @@ import org.hamcrest.Matcher;
  *  See ScalarHasValueTest for an example of a satisfactory result.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class InputHasContent extends MatcherEnvelope<Input> {
+public final class HasContent extends MatcherEnvelope<Input> {
 
     /**
      * Ctor.
      * @param text The text to match against
      */
-    public InputHasContent(final String text) {
+    public HasContent(final String text) {
         this(new TextOf(text));
     }
 
@@ -55,7 +55,7 @@ public final class InputHasContent extends MatcherEnvelope<Input> {
      * Ctor.
      * @param text The text to match against
      */
-    public InputHasContent(final Text text) {
+    public HasContent(final Text text) {
         this(
             new MatcherOf<>(
                 (String input) -> text.asString().equals(input), text
@@ -67,7 +67,7 @@ public final class InputHasContent extends MatcherEnvelope<Input> {
      * Ctor.
      * @param mtr Matcher of the text
      */
-    public InputHasContent(final Matcher<String> mtr) {
+    public HasContent(final Matcher<String> mtr) {
         super(
             new MatcherOf<>(
                 input -> mtr.matches(new TextOf(input).asString()),

--- a/src/main/java/org/llorllale/cactoos/matchers/HasString.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasString.java
@@ -34,13 +34,13 @@ import org.cactoos.text.TextOf;
  *
  * @since 0.2
  */
-public final class TextHasString extends MatcherEnvelope<Text> {
+public final class HasString extends MatcherEnvelope<Text> {
 
     /**
      * Ctor.
      * @param text The text to match against
      */
-    public TextHasString(final String text) {
+    public HasString(final String text) {
         this(new TextOf(text));
     }
 
@@ -48,7 +48,7 @@ public final class TextHasString extends MatcherEnvelope<Text> {
      * Ctor.
      * @param text The text to match against
      */
-    public TextHasString(final Text text) {
+    public HasString(final Text text) {
         super(
             new TextMatcher(
                 new MatcherOf<>(

--- a/src/main/java/org/llorllale/cactoos/matchers/HasValue.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/HasValue.java
@@ -24,52 +24,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.scalar.Constant;
-import org.cactoos.scalar.Unchecked;
+import org.cactoos.Scalar;
+import org.hamcrest.Matcher;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
 
 /**
- * Test case for {@link ScalarHasValue}.
+ * Matcher for the value.
  *
- * @since 1.0
- * @checkstyle JavadocMethodCheck (500 lines)
+ * @param <T> Type of result
+ * @since 0.2
  */
-public final class ScalarHasValueTest {
+public final class HasValue<T> extends MatcherEnvelope<Scalar<T>> {
 
-    @Test
-    public void matchesWithExpectedString() {
-        final String expected = "some text";
-        new Assertion<>(
-            "Must match with expected string",
-            new Unchecked<>(() -> expected),
-            new ScalarHasValue<>(expected)
-        ).affirm();
+    /**
+     * Ctor.
+     * @param value The value to match against
+     */
+    public HasValue(final T value) {
+        this(new IsEqual<>(value));
     }
 
-    @Test
-    public void matchesAsExpectedWithMatcher() {
-        final String expected = "text";
-        new Assertion<>(
-            "Must match a with the given Matcher",
-            new Unchecked<>(() -> expected),
-            new ScalarHasValue<>(new IsEqual<>(expected))
-        ).affirm();
-    }
-
-    @Test
-    public void hasMatcherDescriptionForFailedTest() {
-        new Assertion<>(
-            "correctly describes a mismatch",
-            new ScalarHasValue<>(new IsEqual<>("something")),
-            new Mismatches<>(
-                new Constant<>("something else"),
-                "Scalar with \"something\"",
-                "was \"something else\""
+    /**
+     * Ctor.
+     * @param mtr Matcher of the value
+     */
+    public HasValue(final Matcher<T> mtr) {
+        super(
+            new MatcherOf<>(
+                scalar -> mtr.matches(scalar.value()),
+                desc -> desc.appendText("Scalar with ").appendDescriptionOf(mtr),
+                (scalar, desc) -> mtr.describeMismatch(scalar.value(), desc)
             )
-        ).affirm();
+        );
     }
 }

--- a/src/main/java/org/llorllale/cactoos/matchers/IsApplicable.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/IsApplicable.java
@@ -39,14 +39,14 @@ import org.hamcrest.core.IsEqual;
  * @since 0.2
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class FuncApplies<X, Y> extends MatcherEnvelope<Func<X, Y>> {
+public final class IsApplicable<X, Y> extends MatcherEnvelope<Func<X, Y>> {
 
     /**
      * Ctor.
      * @param inpt Input for the function
      * @param result The result expected
      */
-    public FuncApplies(final X inpt, final Y result) {
+    public IsApplicable(final X inpt, final Y result) {
         this(inpt, new IsEqual<>(result));
     }
 
@@ -55,7 +55,7 @@ public final class FuncApplies<X, Y> extends MatcherEnvelope<Func<X, Y>> {
      * @param input Input for the function
      * @param mtr Matcher of the text
      */
-    public FuncApplies(final X input, final Matcher<Y> mtr) {
+    public IsApplicable(final X input, final Matcher<Y> mtr) {
         super(
             new MatcherOf<>(
                 func -> mtr.matches(

--- a/src/main/java/org/llorllale/cactoos/matchers/IsNumber.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/IsNumber.java
@@ -33,13 +33,13 @@ import java.util.Comparator;
  *
  * @since 1.0.0
  */
-public final class NumberIs extends MatcherEnvelope<Number> {
+public final class IsNumber extends MatcherEnvelope<Number> {
 
     /**
      * Ctor.
      * @param expected The expected value
      */
-    public NumberIs(final Number expected) {
+    public IsNumber(final Number expected) {
         super(
             new MatcherOf<>(
                 expected,

--- a/src/main/java/org/llorllale/cactoos/matchers/IsText.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/IsText.java
@@ -34,13 +34,13 @@ import org.cactoos.text.TextOf;
  *
  * @since 1.0.0
  */
-public final class TextIs extends MatcherEnvelope<Text> {
+public final class IsText extends MatcherEnvelope<Text> {
 
     /**
      * Ctor.
      * @param text The text to match against
      */
-    public TextIs(final String text) {
+    public IsText(final String text) {
         this(new TextOf(text));
     }
 
@@ -48,7 +48,7 @@ public final class TextIs extends MatcherEnvelope<Text> {
      * Ctor.
      * @param text The text to match against
      */
-    public TextIs(final Text text) {
+    public IsText(final Text text) {
         super(
             new TextMatcher(
                 new MatcherOf<>(

--- a/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
@@ -50,7 +50,7 @@ public final class AssertionTest {
         new Assertion<>(
             "must affirm the assertion if the test's result is as expected",
             new TextOf(expected),
-            new TextIs(expected)
+            new IsText(expected)
         ).affirm();
     }
 
@@ -67,7 +67,7 @@ public final class AssertionTest {
             () -> new Assertion<>(
                 "must refute the assertion if the test's result is not as expected",
                 new TextOf("test"),
-                new TextIs("no match")
+                new IsText("no match")
             ).affirm(),
             new Joined(
                 System.lineSeparator(),

--- a/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/AssertionTest.java
@@ -91,7 +91,7 @@ public final class AssertionTest {
                 () -> {
                     throw new IllegalStateException();
                 },
-                new ScalarHasValue<>("no match")
+                new HasValue<>("no match")
             ).affirm()
         );
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/HasContentTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasContentTest.java
@@ -34,20 +34,20 @@ import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
- * Test case for {@link InputHasContent}.
+ * Test case for {@link HasContent}.
  *
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class InputHasContentTest {
+public final class HasContentTest {
 
     @Test
     public void matchesInputContent() {
         final String text = "Hello World!";
         new Assertion<>(
             "matches input with equal contents",
-            new InputHasContent(text),
+            new HasContent(text),
             new Matches<>(new InputOf(text))
         ).affirm();
     }
@@ -56,7 +56,7 @@ public final class InputHasContentTest {
     public void mismatchInputContent() {
         new Assertion<>(
             "does not match input with different contents",
-            new InputHasContent("hello"),
+            new HasContent("hello"),
             new IsNot<>(new Matches<>(new InputOf("world")))
         ).affirm();
     }
@@ -64,7 +64,7 @@ public final class InputHasContentTest {
     @Test
     public void describesMismatch() {
         final Description description = new StringDescription();
-        new InputHasContent("world").describeMismatchSafely(
+        new HasContent("world").describeMismatchSafely(
             new InputOf("hello"), description
         );
         new Assertion<>(
@@ -77,7 +77,7 @@ public final class InputHasContentTest {
     @Test
     public void describesExpectedValues() {
         final Description description = new StringDescription();
-        new InputHasContent("world").describeTo(description);
+        new HasContent("world").describeTo(description);
         new Assertion<>(
             "includes the specified contents when describing itself",
             description.toString(),

--- a/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasPropertyTest.java
@@ -50,7 +50,7 @@ public final class HasPropertyTest {
     public void positiveMatch() {
         new Assertion<>(
             "must match 'a=1'",
-            new ScalarHasValue<>(new HasProperty("a", "1")),
+            new HasValue<>(new HasProperty("a", "1")),
             new Matches<>(new PropertiesOf("a=1"))
         ).affirm();
     }
@@ -62,7 +62,7 @@ public final class HasPropertyTest {
     public void positiveMachKey() {
         new Assertion<>(
             "must match 'b=...'",
-            new ScalarHasValue<>(new HasProperty("b")),
+            new HasValue<>(new HasProperty("b")),
             new Matches<>(new PropertiesOf("b=..."))
         ).affirm();
     }
@@ -74,14 +74,14 @@ public final class HasPropertyTest {
     public void positiveFuzzyMatch() {
         new Assertion<>(
             "must match 'f=q'",
-            new ScalarHasValue<>(
+            new HasValue<>(
                 new HasProperty(
                     new IsEqualIgnoringCase("F"),
                     new IsEqualIgnoringCase("Q")
                 )
             ),
             new AllOf<>(
-                new ListOf<Matcher<? super ScalarHasValue<Properties>>>(
+                new ListOf<Matcher<? super HasValue<Properties>>>(
                     new Matches<>(new PropertiesOf("F=q")),
                     new Matches<>(new PropertiesOf("f=Q")),
                     new Matches<>(new PropertiesOf("f=q"))
@@ -99,9 +99,9 @@ public final class HasPropertyTest {
             "Scalar with has property key \"abc\", value \"1\"";
         new Assertion<>(
             "must mismatches 'abc=2' & 'xyz=1'",
-            new ScalarHasValue<>(new HasProperty("abc", "1")),
+            new HasValue<>(new HasProperty("abc", "1")),
             new AllOf<>(
-                new ListOf<Matcher<? super ScalarHasValue<Properties>>>(
+                new ListOf<Matcher<? super HasValue<Properties>>>(
                     new Mismatches<>(
                         new PropertiesOf("abc=2"),
                         expected,
@@ -124,7 +124,7 @@ public final class HasPropertyTest {
     public void describesCorrectly() {
         new Assertion<>(
             "must have a message that describes the properties",
-            new ScalarHasValue<>(new HasProperty("c", "3")),
+            new HasValue<>(new HasProperty("c", "3")),
             new Mismatches<>(
                 new PropertiesOf("b=2"),
                 "Scalar with has property key \"c\", value \"3\"",

--- a/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasSizeTest.java
@@ -80,7 +80,7 @@ public final class HasSizeTest {
         new Assertion<>(
             "describes mismatch",
             new TextOf(description.toString()),
-            new TextIs(
+            new IsText(
                 new UncheckedText(
                     new FormattedText("has size <%d>", 0)
                 ).asString()

--- a/src/test/java/org/llorllale/cactoos/matchers/HasStringTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasStringTest.java
@@ -31,20 +31,20 @@ import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
- * Test case for {@link TextHasString}.
+ * Test case for {@link HasString}.
  *
  * @since 0.29
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class TextHasStringTest {
+public final class HasStringTest {
 
     @Test
     public void matchesPrefix() {
         new Assertion<>(
             "matches prefix",
-            new TextHasString("123"),
+            new HasString("123"),
             new Matches<>(new TextOf("12345"))
         ).affirm();
     }
@@ -53,7 +53,7 @@ public final class TextHasStringTest {
     public void matchesSuffix() {
         new Assertion<>(
             "matches suffix",
-            new TextHasString("345"),
+            new HasString("345"),
             new Matches<>(new TextOf("12345"))
         ).affirm();
     }
@@ -62,7 +62,7 @@ public final class TextHasStringTest {
     public void matchesInTheMiddle() {
         new Assertion<>(
             "matches substring",
-            new TextHasString("234"),
+            new HasString("234"),
             new Matches<>(new TextOf("12345"))
         ).affirm();
     }
@@ -71,7 +71,7 @@ public final class TextHasStringTest {
     public void mismatch() {
         new Assertion<>(
             "does not match text not containing the given string",
-            new TextHasString("xyz"),
+            new HasString("xyz"),
             new IsNot<>(new Matches<>(new TextOf("abc")))
         ).affirm();
     }
@@ -80,7 +80,7 @@ public final class TextHasStringTest {
     public void describesMismatch() {
         new Assertion<>(
             "describes mismatch correctly",
-            new TextHasString("xyz456"),
+            new HasString("xyz456"),
             new Mismatches<>(
                 new TextOf("abc123"),
                 "Text with \"xyz456\"",

--- a/src/test/java/org/llorllale/cactoos/matchers/HasValueTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/HasValueTest.java
@@ -24,39 +24,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package org.llorllale.cactoos.matchers;
 
-import org.cactoos.Scalar;
-import org.hamcrest.Matcher;
+import org.cactoos.scalar.Constant;
+import org.cactoos.scalar.Unchecked;
 import org.hamcrest.core.IsEqual;
+import org.junit.Test;
 
 /**
- * Matcher for the value.
+ * Test case for {@link HasValue}.
  *
- * @param <T> Type of result
- * @since 0.2
+ * @since 1.0
+ * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class ScalarHasValue<T> extends MatcherEnvelope<Scalar<T>> {
+public final class HasValueTest {
 
-    /**
-     * Ctor.
-     * @param value The value to match against
-     */
-    public ScalarHasValue(final T value) {
-        this(new IsEqual<>(value));
+    @Test
+    public void matchesWithExpectedString() {
+        final String expected = "some text";
+        new Assertion<>(
+            "Must match with expected string",
+            new Unchecked<>(() -> expected),
+            new HasValue<>(expected)
+        ).affirm();
     }
 
-    /**
-     * Ctor.
-     * @param mtr Matcher of the value
-     */
-    public ScalarHasValue(final Matcher<T> mtr) {
-        super(
-            new MatcherOf<>(
-                scalar -> mtr.matches(scalar.value()),
-                desc -> desc.appendText("Scalar with ").appendDescriptionOf(mtr),
-                (scalar, desc) -> mtr.describeMismatch(scalar.value(), desc)
+    @Test
+    public void matchesAsExpectedWithMatcher() {
+        final String expected = "text";
+        new Assertion<>(
+            "Must match a with the given Matcher",
+            new Unchecked<>(() -> expected),
+            new HasValue<>(new IsEqual<>(expected))
+        ).affirm();
+    }
+
+    @Test
+    public void hasMatcherDescriptionForFailedTest() {
+        new Assertion<>(
+            "correctly describes a mismatch",
+            new HasValue<>(new IsEqual<>("something")),
+            new Mismatches<>(
+                new Constant<>("something else"),
+                "Scalar with \"something\"",
+                "was \"something else\""
             )
-        );
+        ).affirm();
     }
 }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsApplicableTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsApplicableTest.java
@@ -30,19 +30,19 @@ import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
- * Test case for {@link FuncApplies}.
+ * Test case for {@link IsApplicable}.
  *
  * @since 1.0
  * @checkstyle JavadocMethodCheck (100 lines)
  * @checkstyle MagicNumber (100 line)
  */
-public final class FuncAppliesTest {
+public final class IsApplicableTest {
 
     @Test
     public void matchFuncs() {
         new Assertion<>(
             "matches function that produces same output from the given input",
-            new FuncApplies<>(1, 1),
+            new IsApplicable<>(1, 1),
             new Matches<>(x -> x)
         ).affirm();
     }
@@ -52,7 +52,7 @@ public final class FuncAppliesTest {
         new Assertion<>(
             // @checkstyle LineLength (1 line)
             "does not match function that produces different output from the given input",
-            new FuncApplies<>(1, 1),
+            new IsApplicable<>(1, 1),
             new IsNot<>(new Matches<>(x -> 3 * x))
         ).affirm();
     }
@@ -61,7 +61,7 @@ public final class FuncAppliesTest {
     public void describesMismatch() {
         new Assertion<>(
             "describes mismatch",
-            new FuncApplies<>(1, 1),
+            new IsApplicable<>(1, 1),
             new Mismatches<>(
                 x -> 3 * x,
                 "Func with <1>",

--- a/src/test/java/org/llorllale/cactoos/matchers/IsNumberTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsNumberTest.java
@@ -30,18 +30,18 @@ import org.cactoos.scalar.MaxOf;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link NumberIs}.
+ * Test case for {@link IsNumber}.
  *
  * @since 1.0.0
  * @checkstyle MagicNumberCheck (500 lines)
  */
-final class NumberIsTest {
+final class IsNumberTest {
 
     @Test
     void matchesDouble() {
         new Assertion<>(
             "must match a double",
-            new NumberIs(Double.POSITIVE_INFINITY),
+            new IsNumber(Double.POSITIVE_INFINITY),
             new Matches<>(Double.POSITIVE_INFINITY)
         ).affirm();
     }
@@ -50,7 +50,7 @@ final class NumberIsTest {
     void mismatchesDouble() {
         new Assertion<>(
             "must mismatch a double",
-            new NumberIs(Double.POSITIVE_INFINITY),
+            new IsNumber(Double.POSITIVE_INFINITY),
             new Mismatches<>(
                 1234,
                 "equals <Infinity>",
@@ -63,7 +63,7 @@ final class NumberIsTest {
     void matchesFloat() {
         new Assertion<>(
             "must match a integer",
-            new NumberIs(10f),
+            new IsNumber(10f),
             new Matches<>(10f)
         ).affirm();
     }
@@ -72,7 +72,7 @@ final class NumberIsTest {
     void matchesLong() {
         new Assertion<>(
             "must match a long",
-            new NumberIs(10L),
+            new IsNumber(10L),
             new Matches<>(10L)
         ).affirm();
     }
@@ -81,7 +81,7 @@ final class NumberIsTest {
     void matchesInteger() {
         new Assertion<>(
             "must match an integer",
-            new NumberIs(10),
+            new IsNumber(10),
             new Matches<>(10)
         ).affirm();
     }
@@ -90,7 +90,7 @@ final class NumberIsTest {
     void matchesNumber() {
         new Assertion<>(
             "must match max value via integer",
-            new NumberIs(12),
+            new IsNumber(12),
             new Matches<>(new MaxOf(12L, 11L))
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/IsTextTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/IsTextTest.java
@@ -31,18 +31,18 @@ import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
- * Tests for {@link TextIs}.
+ * Tests for {@link IsText}.
  * @since 1.0.0
  * @checkstyle JavadocMethodCheck (500 lines)
  */
-public final class TextIsTest {
+public final class IsTextTest {
 
     @Test
     public void match() {
         final String input = "abcde";
         new Assertion<>(
             "must match identical text",
-            new TextIs(input),
+            new IsText(input),
             new Matches<>(new TextOf(input))
         ).affirm();
     }
@@ -51,7 +51,7 @@ public final class TextIsTest {
     public void noMatch() {
         new Assertion<>(
             "must not match text that is not identical",
-            new TextIs("xyz"),
+            new IsText("xyz"),
             new IsNot<>(new Matches<>(new TextOf("abcd")))
         ).affirm();
     }

--- a/src/test/java/org/llorllale/cactoos/matchers/MatchesBeforeTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatchesBeforeTest.java
@@ -51,7 +51,7 @@ public final class MatchesBeforeTest {
             new TextOf(val),
             new MatchesBefore<>(
                 1000,
-                new TextIs(val)
+                new IsText(val)
             )
         ).affirm();
     }
@@ -60,7 +60,7 @@ public final class MatchesBeforeTest {
     public void mismatchesFromMatcher() {
         new Assertion<>(
             "must fail because of matcher",
-            new MatchesBefore<>(1000, new TextIs("a")),
+            new MatchesBefore<>(1000, new IsText("a")),
             new Mismatches<>(
                 new TextOf("b"),
                 "Text with value \"a\" runs in less than <1000L> milliseconds",
@@ -74,7 +74,7 @@ public final class MatchesBeforeTest {
         final String val = "c";
         new Assertion<>(
             "must fail because of timeout",
-            new MatchesBefore<>(10, new TextIs(val)),
+            new MatchesBefore<>(10, new IsText(val)),
             new Mismatches<>(
                 () -> {
                     Thread.sleep(1000);
@@ -91,7 +91,7 @@ public final class MatchesBeforeTest {
         final String val = "c";
         new Assertion<>(
             "description must contain exception happened inside Text",
-            new MatchesBefore<>(20, new TextIs(val)),
+            new MatchesBefore<>(20, new IsText(val)),
             new Mismatches<>(
                 () -> {
                     throw new UnsupportedOperationException();

--- a/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MatchesTest.java
@@ -49,7 +49,7 @@ public final class MatchesTest {
     public void matches() {
         new Assertion<>(
             "Matcher TextIs(abc) gives positive result for Text(abc)",
-            new TextIs("abc"),
+            new IsText("abc"),
             new Matches<>(new TextOf("abc"))
         ).affirm();
     }
@@ -61,7 +61,7 @@ public final class MatchesTest {
     public void matchStatus() {
         new Assertion<>(
             "Matcher TextIs(abc) gives negative result for Text(def)",
-            new Matches<>(new TextOf("def")).matches(new TextIs("abc")),
+            new Matches<>(new TextOf("def")).matches(new IsText("abc")),
             new IsEqual<>(false)
         ).affirm();
     }
@@ -72,8 +72,8 @@ public final class MatchesTest {
     @Test
     public void describeActual() {
         final Description description = new StringDescription();
-        new Matches<Text, TextIs>(new TextOf("expected")).matchesSafely(
-            new TextIs("actual"), description
+        new Matches<Text, IsText>(new TextOf("expected")).matchesSafely(
+            new IsText("actual"), description
         );
         new Assertion<>(
             "describes the matcher",

--- a/src/test/java/org/llorllale/cactoos/matchers/MismatchesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/MismatchesTest.java
@@ -45,7 +45,7 @@ public final class MismatchesTest {
     public void mismatches() {
         new Assertion<>(
             "Must mismatch properly",
-            new TextIs("abc"),
+            new IsText("abc"),
             new Mismatches<>(
                 new TextOf("def"),
                 "Text with value \"abc\"",
@@ -60,7 +60,7 @@ public final class MismatchesTest {
             "Must fail to mismatch",
             new Mismatches<>(new TextOf("a"), new TextOf("expected")),
             new Mismatches<>(
-                new TextIs("a"),
+                new IsText("a"),
                 "Mismatches <a> with message <expected>",
                 ""
            )


### PR DESCRIPTION
#213

- Rename `TextIs` to `IsText`
- Rename `NumberIs` to `IsNumberText`
- Rename `InputHasContent` to `HasContent`
- Rename `TextHasString` to `HasString`
- Rename `ScalarHasValue` to `HasValue`
- Rename `FuncApplies` to `IsApplicable`
