### PR TITLE
(#165) Introduce Verifies to replace one-argument MatcherOf

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/MatcherOf.java
@@ -48,7 +48,7 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
     /**
      * Matches an actual object with expected one.
      */
-    private final Func<T, Boolean> match;
+    private final Func<? super T, Boolean> match;
 
     /**
      * Generates a description of the object.
@@ -59,7 +59,7 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
      * Generates a description for situation when an actual object does not
      * match to the expected one.
      */
-    private final BiProc<T, Description> mismatch;
+    private final BiProc<? super T, Description> mismatch;
 
     /**
      * Ctor.
@@ -69,9 +69,9 @@ public final class MatcherOf<T> extends TypeSafeMatcher<T> {
      *  object does not match to the expected one
      */
     public MatcherOf(
-        final Func<T, Boolean> match,
+        final Func<? super T, Boolean> match,
         final Proc<Description> description,
-        final BiProc<T, Description> mismatch
+        final BiProc<? super T, Description> mismatch
     ) {
         this.match = match;
         this.description = description;

--- a/src/main/java/org/llorllale/cactoos/matchers/Verifies.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/Verifies.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018-2020.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import org.cactoos.Func;
+
+/**
+ * Matches if an object verifies the {@link Func}.
+ *
+ * @param <T> Type of the matched value
+ * @since 1.0.0
+ */
+public final class Verifies<T> extends MatcherEnvelope<T> {
+    /**
+     * Ctor.
+     * @param func Function to verify
+     */
+    public Verifies(final Func<? super T, Boolean> func) {
+        super(
+            new MatcherOf<>(
+                func,
+                desc -> desc.appendText("verifies"),
+                (obj, desc) -> desc.appendText("was ").appendValue(obj)
+            )
+        );
+    }
+}

--- a/src/test/java/org/llorllale/cactoos/matchers/VerifiesTest.java
+++ b/src/test/java/org/llorllale/cactoos/matchers/VerifiesTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018-2020.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.llorllale.cactoos.matchers;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Verifies}.
+ *
+ * @since 1.0.0
+ */
+final class VerifiesTest {
+
+    @Test
+    void matches() {
+        new Assertion<>(
+            "Must match",
+            new Verifies<>(x -> x > 0),
+            new Matches<>(1)
+        ).affirm();
+    }
+
+    @Test
+    void mismatches() {
+        new Assertion<>(
+            "must mismatch",
+            new Verifies<>(x -> x > 1),
+            new Mismatches<>(
+                0,
+                "verifies",
+                "was <0>"
+            )
+        ).affirm();
+    }
+}


### PR DESCRIPTION
This is in the continuation of #165 because sometimes it's required to write assertions with just a predicate