### PR TITLE
(#220) fix shaded jar generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .classpath
 .recommenders
 /nbproject/
+/dependency-reduced.pom

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.50.5</version>
+    <version>0.51.1</version>
   </parent>
   <groupId>org.llorllale</groupId>
   <artifactId>cactoos-matchers</artifactId>
@@ -76,7 +76,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
     </dependency>
   </dependencies>
   <profiles>
@@ -146,8 +145,9 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <!-- This confuses qulice -->
-              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <!-- so that it is not seen by antrun's execution from parent pom, see https://github.com/jcabi/jcabi-parent/issues/117 -->
+              <dependencyReducedPomLocation>${basedir}/dependency-reduced.pom</dependencyReducedPomLocation>
+              <minimizeJar>true</minimizeJar>
               <createSourcesJar>true</createSourcesJar>
               <shadeSourcesContent>true</shadeSourcesContent>
               <artifactSet>
@@ -166,7 +166,6 @@
                   </excludes>
                 </relocation>
               </relocations>
-              <minimizeJar>true</minimizeJar>
             </configuration>
           </execution>
         </executions>
@@ -174,7 +173,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.5</version>
         <configuration>
           <output>file</output>
           <outputDirectory>${project.build.directory}/coverage</outputDirectory>


### PR DESCRIPTION
This is for #220 to fix the maven shade configuration so that the generated jar does not contain cactoos as a dependency.