### PR TITLE
Move collection matchers from cactoos

### DIFF
--- a/src/main/java/org/llorllale/cactoos/matchers/BehavesAsCollection.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/BehavesAsCollection.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018-2020.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import java.util.Collection;
+import org.cactoos.list.ListOf;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.collection.IsEmptyCollection;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
+
+/**
+ * Matcher for collection.
+ * @param <E> Type of source item
+ * @since 0.23
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class BehavesAsCollection<E> extends
+    TypeSafeMatcher<Collection<E>> {
+
+    /**
+     * Sample item.
+     */
+    private final E sample;
+
+    /**
+     * Ctor.
+     * @param item Sample item
+     */
+    public BehavesAsCollection(final E item) {
+        super();
+        this.sample = item;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "PMD.ClassCastExceptionWithToArray"})
+    public boolean matchesSafely(final Collection<E> col) {
+        new Assertion<>(
+            "Must contain item",
+            col,
+            new HasValues<>(this.sample)
+        ).affirm();
+        new Assertion<>(
+            "Must not be empty",
+            col,
+            new IsNot<>(
+                new IsEmptyCollection<>()
+            )
+        ).affirm();
+        new Assertion<>(
+            "Size must be more than 0",
+            col,
+            new IsCollectionWithSize<>(
+                new Satisfies<>(s -> s > 0)
+            )
+        ).affirm();
+        new Assertion<>(
+            "Array must contain item",
+            new ListOf<>(
+                (E[]) col.toArray()
+            ),
+            new HasValues<>(this.sample)
+        ).affirm();
+        final E[] array = (E[]) new Object[col.size()];
+        col.toArray(array);
+        new Assertion<>(
+            "Array from collection must contain item",
+            new ListOf<>(array),
+            new HasValues<>(this.sample)
+        ).affirm();
+        new Assertion<>(
+            "Must contain list with the item",
+            col.containsAll(
+                new ListOf<>(this.sample)
+            ),
+            new IsEqual<>(true)
+        ).affirm();
+        return true;
+    }
+
+    @Override
+    public void describeTo(final Description desc) {
+        desc.appendText("not a valid collection");
+    }
+}

--- a/src/main/java/org/llorllale/cactoos/matchers/BehavesAsList.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/BehavesAsList.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018-2020.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import java.util.List;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
+
+/**
+ * Matcher for collection.
+ * @param <E> Type of source item
+ * @since 0.23
+ */
+public final class BehavesAsList<E> extends TypeSafeMatcher<List<E>> {
+
+    /**
+     * Sample item.
+     */
+    private final E sample;
+
+    /**
+     * Ctor.
+     * @param item Sample item
+     */
+    public BehavesAsList(final E item) {
+        super();
+        this.sample = item;
+    }
+
+    @Override
+    public boolean matchesSafely(final List<E> list) {
+        new Assertion<>(
+            "must contain at least one non-null element",
+            list.get(0),
+            new IsNot<>(new IsNull<>())
+        ).affirm();
+        new Assertion<>(
+            "must have an index for the sample item",
+            list.indexOf(this.sample),
+            new Satisfies<>(i -> i >= 0)
+        ).affirm();
+        new Assertion<>(
+            "must have a last index for the sample item",
+            list.lastIndexOf(this.sample),
+            new Satisfies<>(i -> i >= 0)
+        ).affirm();
+        new Assertion<>(
+            "must have at least one element in list iterator",
+            list.listIterator().hasNext(),
+            new IsTrue()
+        ).affirm();
+        new Assertion<>(
+            "must have at least one element in sublist iterator",
+            list.subList(0, 1).iterator().hasNext(),
+            new IsTrue()
+        ).affirm();
+        return new BehavesAsCollection<E>(this.sample).matchesSafely(list);
+    }
+
+    @Override
+    public void describeTo(final Description desc) {
+        desc.appendText("not a valid list");
+    }
+}

--- a/src/main/java/org/llorllale/cactoos/matchers/BehavesAsMap.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/BehavesAsMap.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018-2020.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import java.util.Map;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher for collection.
+ * @param <K> Type of key
+ * @param <V> Type of value
+ * @since 0.24
+ * @checkstyle JavadocMethodCheck (500 lines)
+ */
+public final class BehavesAsMap<K, V> extends TypeSafeMatcher<Map<K, V>> {
+
+    /**
+     * Sample key.
+     */
+    private final K key;
+
+    /**
+     * Sample value.
+     */
+    private final V value;
+
+    /**
+     * Ctor.
+     * @param akey Sample key
+     * @param val Sample value
+     */
+    public BehavesAsMap(final K akey, final V val) {
+        super();
+        this.key = akey;
+        this.value = val;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean matchesSafely(final Map<K, V> map) {
+        new Assertion<>(
+            "Must contain the key/value entry",
+            map,
+            new HasEntry<>(this.key, this.value)
+        ).affirm();
+        new Assertion<>(
+            "Must contain the key in #keySet()",
+            map.keySet(),
+            new HasValues<>(this.key)
+        ).affirm();
+        new Assertion<>(
+            "Must contain the value in #values()",
+            map.values(),
+            new HasValues<>(this.value)
+        ).affirm();
+        return true;
+    }
+
+    @Override
+    public void describeTo(final Description desc) {
+        desc.appendText("not a valid map");
+    }
+}

--- a/src/main/java/org/llorllale/cactoos/matchers/BehavesAsSet.java
+++ b/src/main/java/org/llorllale/cactoos/matchers/BehavesAsSet.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) for portions of project cactoos-matchers are held by
+ * Yegor Bugayenko, 2017-2018, as part of project cactoos.
+ * All other copyright for project cactoos-matchers are held by
+ * George Aristy, 2018-2020.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.llorllale.cactoos.matchers;
+
+import java.util.Iterator;
+import java.util.Set;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsEqual;
+
+/**
+ * Matcher for set.
+ *
+ * @param <T> Type of source sample
+ * @since 0.49.2
+ */
+public final class BehavesAsSet<T> extends TypeSafeMatcher<Set<T>> {
+
+    /**
+     * Sample sample.
+     */
+    private final T sample;
+
+    /**
+     * Ctor.
+     * @param item Sample sample
+     */
+    public BehavesAsSet(final T item) {
+        super();
+        this.sample = item;
+    }
+
+    @Override
+    public boolean matchesSafely(final Set<T> item) {
+        new Assertion<>(
+            "Does not contain duplicates",
+            this.occurrences(item.iterator()),
+            new IsEqual<>(1)
+        ).affirm();
+        return new BehavesAsCollection<>(this.sample).matchesSafely(item);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("not a valid set");
+    }
+
+    /**
+     * Occurrences of sample in iterator.
+     * @param iterator Set iterator
+     * @return Occurrences
+     */
+    private int occurrences(final Iterator<T> iterator) {
+        int occurrences = 0;
+        while (iterator.hasNext()) {
+            if (this.sample.equals(iterator.next())) {
+                ++occurrences;
+            }
+        }
+        return occurrences;
+    }
+}


### PR DESCRIPTION
Per https://github.com/yegor256/cactoos/issues/1503

- Move `Behaves*` classes from cactoos